### PR TITLE
Add optional custom pinnumbers to connector

### DIFF
--- a/src/wireviz.py
+++ b/src/wireviz.py
@@ -82,16 +82,23 @@ class Harness:
                 # a = attributes
                 a = [n.type,
                      n.subtype,
-                     '{}-pin'.format(len(n.pinout)) if n.show_pincount else '']
+                     '{}-pin'.format(n.pincount) if n.show_pincount else '']
                 # p = pinout
                 p = [[],[],[]]
                 p[1] = list(n.pinout)
-                for i, x in enumerate(n.pinout, 1):
-                    if n.ports_left:
-                        p[0].append('<p{portno}l>{portno}'.format(portno=i))
-                    if n.ports_right:
-                        p[2].append('<p{portno}r>{portno}'.format(portno=i))
-                # l = label
+                if (n.pinnumbers):
+                    for i in n.pinnumbers:
+                        if n.ports_left:
+                            p[0].append('<p{portno}l>{portno}'.format(portno=i))
+                        if n.ports_right:
+                            p[2].append('<p{portno}r>{portno}'.format(portno=i))
+                else:
+                    for i, x in enumerate(n.pinout, 1):
+                        if n.ports_left:
+                            p[0].append('<p{portno}l>{portno}'.format(portno=i))
+                        if n.ports_right:
+                            p[2].append('<p{portno}r>{portno}'.format(portno=i))
+                    # l = label
                 l = [n.name if n.show_name else '', a, p, n.notes]
                 dot.node(k, label=nested(l))
 
@@ -318,6 +325,7 @@ class Connector:
     pincount: int = None
     notes: str = None
     pinout: List[Any] = field(default_factory=list)
+    pinnumbers: List[Any] = field(default_factory=list)
     color: str = None
     show_name: bool = True
     show_pincount: bool = True
@@ -327,15 +335,17 @@ class Connector:
         self.ports_right = False
         self.loops = []
 
-        if self.pinout:
-            if self.pincount is not None:
-                raise Exception('You cannot specify both pinout and pincount')
-            else:
+        if self.pincount is None:
+            if self.pinout:
                 self.pincount = len(self.pinout)
-        else:
-            if not self.pincount:
-                self.pincount = 1
-            self.pinout = ['',] * self.pincount
+            elif self.pinnumbers:
+                self.pincount = len(self.pinnumbers)
+            else:
+                raise Exception('You need to specify at least one, pincount, pinout or pinnumbers')
+
+        if self.pinout and self.pinnumbers:
+            if len(self.pinout) != len(self.pinnumbers):
+                raise Exception('Given pinout and pinnumbers size mismatch')
 
     def loop(self, from_pin, to_pin):
         self.loops.append((from_pin, to_pin))


### PR DESCRIPTION
One possible solution for custom pin numbering, e.g. fits needs in #4 

- Pincount is detected automatically if not given.
- If both, pinout and pinnumbers, are given, their count must match.
- Freedom to give pin numbers in any order, in alphabetical and mixed notation.

Sample

```
connectors:
  X1:
    type: D-Sub
    subtype: male
    pincount: 25
    pinnumbers: [1,14,3,16,5,18,7,20,9,22,11,24,13]
    pinout: [ SENSE_P_1, SENSE_N_1, SENSE_P_2, SENSE_N_2, SENSE_P_3, SENSE_N_3, SENSE_P_4,SENSE_N_4, SENSE_P_5, SENSE_N_5, SENSE_P_6, SENSE_N_6, GND ]
  X2:
    type: F48
    subtype: female
    pincount: 48
    pinnumbers: [ z2,b2,d2,z4,b4,d4,z6,b6,d6,z8,b8,d8,z10,b10,d10,z12,b12,d12,z14,b14,d14,z16,b16,d16,z18,b18,d18,z20,b20,d20,z22,b22,d22,z24,b24,d24,z26,b26,d26,z28,b28,d28,z30,b30,d30,z32,b32,d32 ]

cables:
  W1:
    gauge: 0.25 mm2
    length: 0.2
    color_code: DIN
    wirecount: 16
    shield: true

connections:
  -
    - X1: [1,14,3,16,5,18,7,20,9,22,11,24]
    - W1: [2,1,4,3,6,5,8,7,10,9,12,11]
    - X2: [d4,z2,d10,z8,d16,z14,d20,z18,d26,z24,d32,z30]
  -
    - X1: 13
    - W1: s

```
![demo01](https://user-images.githubusercontent.com/4472660/85619100-71c8e000-b66a-11ea-80ba-f22cf26c2a2d.png)
