### PR TITLE
[ci] Add Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: Create Examples
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup Graphviz
+      uses: ts-graphviz/setup-graphviz@v1
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+    - name: Create Examples
+      run: PYTHONPATH=$(pwd)/src:$PYTHONPATH cd src/wireviz/ && python build_examples.py


### PR DESCRIPTION
This add a Github Actions workflow which 
- sets up an Ubuntu image with graphviz & Python 3.7 + 3.8
- runs `build_examples.py` as an integration test
- is executed on each pull/pull request

The workflow can be extended to run some helpful analysis tools, e.g. `pylint` (Python linter), `mypy` (Pyhton type checking), `black` (format checker).