### PR TITLE
Fix for Designators apearing across all colours of wires of a guage.

### DIFF
--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -287,15 +287,13 @@ class Harness:
                 for bundle in items.values():
                     # add each wire from each bundle to the wirelist
                     for color in bundle.colors:
-                        wirelist.append({'gauge': shared.gauge, 'gauge_unit': shared.gauge_unit, 'length': shared.length, 'color': color, 'designators': list(items.keys())})
+                        wirelist.append({'gauge': shared.gauge, 'gauge_unit': shared.gauge_unit, 'length': shared.length, 'color': color, 'designator': bundle.name})
         # join similar wires from all the bundles to a single BOM item
         types = Counter([(v['gauge'], v['gauge_unit'], v['color']) for v in wirelist])
         for type in types:
             items = [v for v in wirelist if (v['gauge'], v['gauge_unit'], v['color']) == type]
             shared = items[0]
-            designators = [i['designators'] for i in items]
-            # flatten nested list
-            designators = [item for sublist in designators for item in sublist] # https://stackoverflow.com/a/952952
+            designators = [i['designator'] for i in items]
             # remove duplicates
             designators = list(dict.fromkeys(designators))
             designators.sort()


### PR DESCRIPTION
This fixes #33 where designators appear across all wires of a guage rather than just the ones that use that colour.

The result of the testcase in that issue can be seen below.
![image](https://user-images.githubusercontent.com/3390465/85957125-b2826b00-b982-11ea-9d47-1147ef079571.png)

