### PR TITLE
Add ability for `parse` to return the `Harness` instance

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -9,6 +9,7 @@ from wireviz.wv_helper import awg_equiv, mm2_equiv, tuplelist2tsv, nested, \
     graphviz_line_breaks, remove_line_breaks
 from collections import Counter
 from typing import List
+from pathlib import Path
 
 
 class Harness:
@@ -279,13 +280,13 @@ class Harness:
         data.seek(0)
         return data.read()
 
-    def output(self, filename, directory='_output', view=False, cleanup=True, fmt=('pdf', )):
+    def output(self, filename: (str, Path), view=False, cleanup=True, fmt=('pdf', )):
         # graphical output
         graph = self.create_graph()
         for f in fmt:
             graph.format = f
-            graph.render(filename=filename, directory=directory, view=view, cleanup=cleanup)
-        graph.save(filename=f'{filename}.gv', directory=directory)
+            graph.render(filename=filename, view=view, cleanup=cleanup)
+        graph.save(filename=f'{filename}.gv')
         # bom output
         bom_list = self.bom_list()
         with open(f'{filename}.bom.tsv', 'w') as file:

--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -25,8 +25,10 @@ def parse(yaml_input, file_out=None, return_types: (None, str, Tuple[str]) = Non
     :param return_types: if None, then returns None; if the value is a string, then a
         corresponding data format will be returned; if the value is a tuple of strings,
         then for every valid format in the `return_types` tuple, another return type
-        will be generated and returned in the same order; currently supports only 'png',
-        but could easily support other types
+        will be generated and returned in the same order; currently supports:
+         - "png" - will return the PNG data
+         - "svg" - will return the SVG data
+         - "harness" - will return the `Harness` instance
     """
 
     yaml_data = yaml.safe_load(yaml_input)
@@ -173,7 +175,6 @@ def parse(yaml_input, file_out=None, return_types: (None, str, Tuple[str]) = Non
         for line in yaml_data["additional_bom_items"]:
             harness.add_bom_item(line)
 
-
     if file_out is not None:
         harness.output(filename=file_out, fmt=('png', 'svg'), view=False)
 
@@ -188,6 +189,8 @@ def parse(yaml_input, file_out=None, return_types: (None, str, Tuple[str]) = Non
             returns.append(harness.png)
         if 'svg' in return_types:
             returns.append(harness.svg)
+        if 'harness' in return_types:
+            returns.append(harness)
 
         return tuple(returns) if len(returns) != 1 else returns[0]
 


### PR DESCRIPTION
In creating the GUI, I am attempting to pull information from the `Harness` class.  The `parse` function throws away the `Harness` instance and I am trying to get access to that information.