### PR TITLE
Allow cleaning of examples

### DIFF
--- a/src/wireviz/build_examples.py
+++ b/src/wireviz/build_examples.py
@@ -1,57 +1,110 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
-
+import argparse
 import os
 import sys
+from fnmatch import fnmatch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from wireviz import wireviz
 
-demos     = 2 # 2
-examples  = 9 # 9
-tutorials = 8 # 7
+examples_path = os.path.join('..','..','examples')
+tutorials_path = os.path.join('..','..','tutorial')
+demos_path = examples_path
 
-if demos:
-    for i in range(1,demos+1):
-        fn = '../../examples/demo{:02d}.yml'.format(i)
-        print(fn)
-        wireviz.parse_file(fn)
+readme = 'readme.md'
 
-if examples:
-    with open(os.path.abspath('../../examples/readme.md'), 'w') as file:
+
+def build_demos():
+    for fn in os.listdir(demos_path):
+        if fnmatch(fn, "demo*.yml"):
+            abspath = os.path.join(demos_path, fn)
+
+            print(abspath)
+            wireviz.parse_file(abspath)
+
+def build_examples():
+    with open(os.path.join(examples_path, readme), 'w') as file:
         file.write('# Example gallery\n')
-        for i in range(1,examples+1):
-            fn = '../../examples/ex{:02d}.yml'.format(i)
-            print(fn)
-            wireviz.parse_file(fn)
+        for fn in os.listdir(examples_path):
+            if fnmatch(fn, "ex*.yml"):
+                i = ''.join(filter(str.isdigit, fn))
 
-            file.write('## Example {:02d}\n'.format(i))
-            file.write('![](ex{:02d}.png)\n\n'.format(i))
-            file.write('[Source](ex{:02d}.yml) - [Bill of Materials](ex{:02d}.bom.tsv)\n\n\n'.format(i,i))
+                abspath = os.path.join(examples_path, fn)
+                outfile_name = abspath.split(".yml")[0]
 
-if tutorials:
-    with open(os.path.abspath('../../tutorial/readme.md'), 'w') as file:
+
+                print(abspath)
+                wireviz.parse_file(abspath)
+
+                file.write(f'## Example {i}\n')
+                file.write(f'![]({outfile_name}.png)\n\n')
+                file.write(f'[Source]({fn}) - [Bill of Materials]({outfile_name}.bom.tsv)\n\n\n')
+
+def build_tutorials():
+    with open(os.path.join(tutorials_path, readme), 'w') as file:
         file.write('# WireViz Tutorial\n')
-        for i in range(1,tutorials+1):
-            fn = '../../tutorial/tutorial{:02d}.yml'.format(i)
-            print(fn)
-            wireviz.parse_file(fn)
+        for fn in os.listdir(tutorials_path):
+            if fnmatch(fn, "tutorial*.yml"):
+                i = ''.join(filter(str.isdigit, fn))
+                abspath = os.path.join(tutorials_path, fn)
+                print(abspath)
 
-            with open(os.path.abspath('../../tutorial/tutorial{:02d}.md'.format(i)), 'r') as info:
-                for line in info:
-                    file.write(line.replace('## ', '## {} - '.format(i)))
-            file.write('\n[Source](tutorial{:02d}.yml):\n\n'.format(i))
+                wireviz.parse_file(abspath)
 
-            with open(os.path.abspath('../../tutorial/tutorial{:02d}.yml'.format(i)), 'r') as src:
-                file.write('```yaml\n')
-                for line in src:
-                    file.write(line)
-                file.write('```\n')
-            file.write('\n')
+                outfile_name = abspath.split(".yml")[0]
 
-            file.write('\nOutput:\n\n'.format(i))
+                with open(outfile_name + '.md', 'r') as info:
+                    for line in info:
+                        file.write(line.replace('## ', '## {} - '.format(i)))
+                file.write(f'\n[Source]({fn}):\n\n')
 
-            file.write('![](tutorial{:02d}.png)\n\n'.format(i))
+                with open(abspath, 'r') as src:
+                    file.write('```yaml\n')
+                    for line in src:
+                        file.write(line)
+                    file.write('```\n')
+                file.write('\n')
 
-            file.write('[Bill of Materials](tutorial{:02d}.bom.tsv)\n\n\n'.format(i))
+                file.write('\nOutput:\n\n'.format(i))
+
+                file.write(f'![](tutorial{outfile_name}.png)\n\n')
+
+                file.write(f'[Bill of Materials](tutorial{outfile_name}.bom.tsv)\n\n\n')
+
+def clean_examples():
+    generated_extensions = ['.gv', '.png', '.svg', '.html', '.bom.tsv']
+
+    for filepath in [examples_path, demos_path, tutorials_path]:
+        print(filepath)
+        for file in os.listdir(filepath):
+            if os.path.exists(os.path.join(filepath, file)):
+                if list(filter(file.endswith, generated_extensions)) or file == 'readme.md':
+                    print('rm ' + os.path.join(filepath, file))
+                    os.remove(os.path.join(filepath, file))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Wireviz Example Manager',
+    )
+    parser.add_argument('action', nargs='?', action='store', default='build')
+    parser.add_argument('-generate', nargs='*', choices=['examples', 'demos', 'tutorials'], default=['examples', 'demos', 'tutorials'])
+    return parser.parse_args()
+def main():
+    args = parse_args()
+    if args.action == 'build':
+        generate_types = {
+            'examples': build_examples,
+            'demos': build_demos,
+            'tutorials': build_tutorials
+        }
+        for gentype in args.generate:
+            if gentype in generate_types:
+                generate_types.get(gentype) ()
+    elif args.action == 'clean':
+        clean_examples()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
build_examples supports cleaning examples and intelligently will detect new examples.

SUGGESTION: When merging into dev, require
```
build_examples.py clean
```

and then only build when merging into master branch


This should allow easier merges, especially from windows, and I am using it as part of a resolution to one of the requests in #17 