### PR TITLE
Avoid Improper XML and DOCTYPE Declarations

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -305,6 +305,7 @@ class Harness:
             file.write(tuplelist2tsv(bom_list))
         # HTML output
         with open(f'{filename}.html', 'w') as file:
+            file.write('<!DOCTYPE html>\n')
             file.write('<html><body style="font-family:Arial">')
 
             file.write('<h1>Diagram</h1>')

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -10,6 +10,7 @@ from wireviz.wv_helper import awg_equiv, mm2_equiv, tuplelist2tsv, \
 from collections import Counter
 from typing import List
 from pathlib import Path
+import re
 
 
 class Harness:
@@ -308,6 +309,10 @@ class Harness:
 
             file.write('<h1>Diagram</h1>')
             with open(f'{filename}.svg') as svg:
+                file.write(re.sub(
+                    '^<[?]xml [^?>]*[?]>[^<]*<!DOCTYPE [^>]*>',
+                    '<!-- XML and DOCTYPE declarations from SVG file removed -->',
+                    svg.read(1024), 1))
                 for svgdata in svg:
                     file.write(svgdata)
 


### PR DESCRIPTION
Fix issue #97 
- Remove XML and DOCTYPE declarations from embedded SVG
- Add DOCTYPE declaration in HTML output
