### PR TITLE
Refactor build_examples.py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,3 @@ jobs:
         pip install .
     - name: Create Examples
       run: PYTHONPATH=$(pwd)/src:$PYTHONPATH cd src/wireviz/ && python build_examples.py
-    - name: Upload examples, demos, and tutorials
-      uses: actions/upload-artifact@v2
-      with:
-        name: examples-and-tutorials
-        path: |
-          examples/
-          tutorial/

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -118,3 +118,6 @@ def open_file_read(filename):
 
 def open_file_write(filename):
     return open(filename, 'w', encoding='UTF-8')
+
+def open_file_append(filename):
+    return open(filename, 'a', encoding='UTF-8')


### PR DESCRIPTION
- Use `pathlib.Path` instead of `os.path`
- Fix order of files while building
- Consolidate code for building demos, examples and tutorial
- Change argument from `tutorials` to `tutorial` to remain consistent
- Add some indentation in console output for better readability