### PR TITLE
Fix HTML color code appearing in wire node

### DIFF
--- a/src/wireviz/wv_colors.py
+++ b/src/wireviz/wv_colors.py
@@ -119,7 +119,7 @@ def get_color_hex(input, pad=False):
 
 def translate_color(input, color_mode):
     if input == '' or input is None:
-        return color_default
+        return ''
     upper = color_mode.isupper()
     if not (color_mode.isupper() or color_mode.islower()):
         raise Exception('Unknown color mode capitalization')


### PR DESCRIPTION
...when no color is specified.

Fixes the bug seen in the [previous PR](https://github.com/formatc1702/WireViz/pull/104#pullrequestreview-451542527) of `#ffffff` appearing inside the node when wire colors are not specified.