### PR TITLE
Feature/additional components

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -43,9 +43,12 @@ additional_bom_items:  # custom items to add to BOM
   notes: <str>   
 
   # product information (all optional)
-  pn: <str>            # [internal] part number
-  mpn: <str>           # manufacturer part number
-  manufacturer: <str>  # manufacturer name
+  ignore_in_bom: <bool>  # if set to true the connector is not added to the BOM
+  pn: <str>              # [internal] part number
+  mpn: <str>             # manufacturer part number
+  manufacturer: <str>    # manufacturer name
+  additional_components: # additional components
+    - <additional-component> # additional component (see below)
 
   # pinout information
   # at least one of the following must be specified
@@ -108,9 +111,12 @@ Since the auto-incremented and auto-assigned designator is not known to the user
   notes: <str>   
 
   # product information (all optional)
-  pn: <str>            # [internal] part number
-  mpn: <str>           # manufacturer part number
-  manufacturer: <str>  # manufacturer name
+  ignore_in_bom: <bool>  # if set to true the cable or wires are not added to the BOM
+  pn: <str>              # [internal] part number
+  mpn: <str>             # manufacturer part number
+  manufacturer: <str>    # manufacturer name
+  additional_components: # additional components
+    - <additional-component> # additional component (see below)
 
   # conductor information
   # the following combinations are permitted:
@@ -212,27 +218,42 @@ For connectors with `autogenerate: true`, a new instance, with auto-generated de
   - `<int>-<int>` auto-expands to a range.
 
 
-## BOM items
+## BOM items and additional components
 
-Connectors (both regular, and auto-generated), cables, and wires of a bundle are automatically added to the BOM.
+Connectors (both regular, and auto-generated), cables, and wires of a bundle are automatically added to the BOM,
+unless the `ignore_in_bom` attribute is set to `true`.
+Additional items can be added to the BOM as either part of a connector or cable or on their own.
 
-<!-- unless the `ignore_in_bom` attribute is set to `true` (#115) -->
+Parts can be added to a connector or cable in the section `<additional-component>` which will also list them in the graph.
 
-Additional BOM entries can be generated in the sections marked `<bom-item>` above.
+```yaml
+-
+  type: <str>  # type of additional component
+  # all the following are optional:
+  subtype: <str>  # additional description (only shown in bom)
+  qty: <int/float>  # qty to add to the bom (defaults to 1)
+  qty_multiplier: <str>  # multiplies qty by a feature of the parent component
+                  # when used in a connector:
+                  # pincount         number of pins of connector
+                  # populated        number of populated positions in a connector
+                  # when used in a cable:
+                  # wirecount        number of wires of cable/bundle
+                  # terminations     number of terminations on a cable/bundle
+                  # length           length of cable/bundle
+                  # total_length     sum of lengths of each wire in the bundle
+  unit: <str>
+  pn: <str>            # [internal] part number
+  mpn: <str>           # manufacturer part number
+  manufacturer: <str>  # manufacturer name  
+```
 
-<!-- BOM items inside connectors/cables are not implemented yet, but should be soon (#50) -->
+Alternatively items can be added to just the BOM by putting them in the section `<bom-item>` above.
 
 ```yaml
 -
   description: <str>              
-  qty: <int/str>  # when used in the additional_bom_items section:
-                  # <int>            manually specify qty.
-                  # when used within a component:
-                  # <int>            manually specify qty.
-                  # pincount         match number of pins of connector
-                  # wirecount        match number of wires of cable/bundle
-                  # connectioncount  match number of connected pins
   # all the following are optional:
+  qty: <int/float>  # qty to add to the bom (defaults to 1)
   unit: <str>   
   designators: <List>
   pn: <str>            # [internal] part number

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from wireviz.wv_helper import int2tuple, aspect_ratio
 from wireviz import wv_colors
 
+# Literal type aliases below are commented to avoid requiring python 3.8
 ConnectorMultiplier = str  # = Literal['pincount', 'populated']
 CableMultiplier = str  # = Literal['wirecount', 'terminations', 'length', 'total_length']
 
@@ -59,7 +60,7 @@ class AdditionalComponent:
 
     @property
     def description(self) -> str:
-        return self.type.capitalize().strip() + (f', {self.subtype.strip()}' if self.subtype else '')
+        return self.type.rstrip() + (f', {self.subtype.rstrip()}' if self.subtype else '')
 
 
 @dataclass

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -59,8 +59,7 @@ class AdditionalComponent:
 
     @property
     def description(self) -> str:
-        name_subtype = f', {self.subtype}' if self.subtype else ''
-        return f'{self.type.capitalize()}{name_subtype}'
+        return self.type.capitalize() + (f', {self.subtype}' if self.subtype else '')
 
 
 @dataclass

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -66,6 +66,7 @@ class Connector:
     autogenerate: bool = False
     loops: List[Any] = field(default_factory=list)
     ignore_in_bom: bool = False
+    additional_components: List[Any] = None
 
     def __post_init__(self):
 

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -43,6 +43,21 @@ class Image:
                 if self.width:
                     self.height = self.width / aspect_ratio(gv_dir.joinpath(self.src))
 
+@dataclass
+class AdditionalComponent:
+    type: str
+    subtype: Optional[str] = None
+    manufacturer: Optional[str] = None
+    mpn: Optional[str] = None
+    pn: Optional[str] = None
+    qty: float = 1
+    unit: Optional[str] = None
+    qty_multiplier: Optional[str] = None
+
+    def long_name(self) -> str:
+        name_subtype = f', {self.subtype}' if self.subtype else ''
+        return f'{self.type.capitalize()}{name_subtype}'
+
 
 @dataclass
 class Connector:
@@ -66,7 +81,7 @@ class Connector:
     autogenerate: bool = False
     loops: List[Any] = field(default_factory=list)
     ignore_in_bom: bool = False
-    additional_components: List[Any] = None
+    additional_components: List[AdditionalComponent] = field(default_factory=list)
 
     def __post_init__(self):
 
@@ -116,10 +131,9 @@ class Connector:
             if len(loop) != 2:
                 raise Exception('Loops must be between exactly two pins!')
 
-        if self.additional_components:
-            for additional_component in self.additional_components:
-                if 'type' not in additional_component:
-                    raise Exception('Additional components must have a type specified')
+        for i, item in enumerate(self.additional_components):
+            if isinstance(item, dict):
+                self.additional_components[i] = AdditionalComponent(**item)
 
     def activate_pin(self, pin):
         self.visible_pins[pin] = True
@@ -147,7 +161,7 @@ class Cable:
     show_name: bool = True
     show_wirecount: bool = True
     ignore_in_bom: bool = False
-    additional_components: List[Any] = None
+    additional_components: List[AdditionalComponent] = field(default_factory=list)
 
     def __post_init__(self):
 
@@ -205,11 +219,9 @@ class Cable:
                 else:
                     raise Exception('lists of part data are only supported for bundles')
 
-        if self.additional_components:
-            for additional_component in self.additional_components:
-                if 'type' not in additional_component:
-                    raise Exception('Additional components must have a type specified')
-
+        for i, item in enumerate(self.additional_components):
+            if isinstance(item, dict):
+                self.additional_components[i] = AdditionalComponent(**item)
 
     def connect(self, from_name, from_pin, via_pin, to_name, to_pin):
         from_pin = int2tuple(from_pin)

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -10,6 +10,7 @@ from wireviz import wv_colors
 ConnectorMultiplier = str  # = Literal['pincount', 'populated']
 CableMultiplier = str  # = Literal['wirecount', 'terminations', 'length', 'total_length']
 
+
 @dataclass
 class Image:
     gv_dir: InitVar[Path] # Directory of .gv file injected as context during parsing
@@ -56,7 +57,7 @@ class AdditionalComponent:
     unit: Optional[str] = None
     qty_multiplier: Union[ConnectorMultiplier, CableMultiplier, None] = None
 
-    def long_name(self) -> str:
+    def description(self) -> str:
         name_subtype = f', {self.subtype}' if self.subtype else ''
         return f'{self.type.capitalize()}{name_subtype}'
 
@@ -139,6 +140,16 @@ class Connector:
 
     def activate_pin(self, pin):
         self.visible_pins[pin] = True
+
+    def get_qty_multiplier(self, qty_multiplier: Optional[ConnectorMultiplier]) -> int:
+        if not qty_multiplier:
+            return 1
+        elif qty_multiplier == 'pincount':
+            return self.pincount
+        elif qty_multiplier == 'populated':
+            return sum(self.visible_pins.values())
+        else:
+            raise ValueError(f'invalid qty multiplier parameter for connector {qty_multiplier}')
 
 
 @dataclass
@@ -234,6 +245,20 @@ class Cable:
         for i, _ in enumerate(from_pin):
             # self.connections.append((from_name, from_pin[i], via_pin[i], to_name, to_pin[i]))
             self.connections.append(Connection(from_name, from_pin[i], via_pin[i], to_name, to_pin[i]))
+
+    def get_qty_multiplier(self, qty_multiplier: Optional[CableMultiplier]) -> float:
+        if not qty_multiplier:
+            return 1
+        elif qty_multiplier == 'wirecount':
+            return self.wirecount
+        elif qty_multiplier == 'terminations':
+            return len(self.connections)
+        elif qty_multiplier == 'length':
+            return self.length
+        elif qty_multiplier == 'total_length':
+            return self.length * self.wirecount
+        else:
+            raise ValueError(f'invalid qty multiplier parameter for cable {qty_multiplier}')
 
 
 @dataclass

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -142,6 +142,7 @@ class Cable:
     show_name: bool = True
     show_wirecount: bool = True
     ignore_in_bom: bool = False
+    additional_components: List[Any] = None
 
     def __post_init__(self):
 

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from wireviz.wv_helper import int2tuple, aspect_ratio
 from wireviz import wv_colors
 
+ConnectorMultiplier = str  # = Literal['pincount', 'populated']
+CableMultiplier = str  # = Literal['wirecount', 'terminations', 'length', 'total_length']
 
 @dataclass
 class Image:
@@ -52,7 +54,7 @@ class AdditionalComponent:
     pn: Optional[str] = None
     qty: float = 1
     unit: Optional[str] = None
-    qty_multiplier: Optional[str] = None
+    qty_multiplier: Union[ConnectorMultiplier, CableMultiplier, None] = None
 
     def long_name(self) -> str:
         name_subtype = f', {self.subtype}' if self.subtype else ''

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -116,6 +116,10 @@ class Connector:
             if len(loop) != 2:
                 raise Exception('Loops must be between exactly two pins!')
 
+        for additional_component in self.additional_components:
+            if 'type' not in additional_component:
+                raise Exception('Additional components must have a type specified')
+
     def activate_pin(self, pin):
         self.visible_pins[pin] = True
 
@@ -199,6 +203,10 @@ class Cable:
                         raise Exception('lists of part data must match wirecount')
                 else:
                     raise Exception('lists of part data are only supported for bundles')
+
+        for additional_component in self.additional_components:
+            if 'type' not in additional_component:
+                raise Exception('Additional components must have a type specified')
 
 
     def connect(self, from_name, from_pin, via_pin, to_name, to_pin):

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -57,6 +57,7 @@ class AdditionalComponent:
     unit: Optional[str] = None
     qty_multiplier: Union[ConnectorMultiplier, CableMultiplier, None] = None
 
+    @property
     def description(self) -> str:
         name_subtype = f', {self.subtype}' if self.subtype else ''
         return f'{self.type.capitalize()}{name_subtype}'

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -65,6 +65,7 @@ class Connector:
     hide_disconnected_pins: bool = False
     autogenerate: bool = False
     loops: List[Any] = field(default_factory=list)
+    ignore_in_bom: bool = False
 
     def __post_init__(self):
 
@@ -139,6 +140,7 @@ class Cable:
     color_code: Optional[str] = None
     show_name: bool = True
     show_wirecount: bool = True
+    ignore_in_bom: bool = False
 
     def __post_init__(self):
 

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -59,7 +59,7 @@ class AdditionalComponent:
 
     @property
     def description(self) -> str:
-        return self.type.capitalize() + (f', {self.subtype}' if self.subtype else '')
+        return self.type.capitalize().strip() + (f', {self.subtype.strip()}' if self.subtype else '')
 
 
 @dataclass

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -116,9 +116,10 @@ class Connector:
             if len(loop) != 2:
                 raise Exception('Loops must be between exactly two pins!')
 
-        for additional_component in self.additional_components:
-            if 'type' not in additional_component:
-                raise Exception('Additional components must have a type specified')
+        if self.additional_components:
+            for additional_component in self.additional_components:
+                if 'type' not in additional_component:
+                    raise Exception('Additional components must have a type specified')
 
     def activate_pin(self, pin):
         self.visible_pins[pin] = True
@@ -204,9 +205,10 @@ class Cable:
                 else:
                     raise Exception('lists of part data are only supported for bundles')
 
-        for additional_component in self.additional_components:
-            if 'type' not in additional_component:
-                raise Exception('Additional components must have a type specified')
+        if self.additional_components:
+            for additional_component in self.additional_components:
+                if 'type' not in additional_component:
+                    raise Exception('Additional components must have a type specified')
 
 
     def connect(self, from_name, from_pin, via_pin, to_name, to_pin):

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -378,7 +378,7 @@ class Harness:
                                + (f', {connector.pincount} pins' if connector.show_pincount else '')
                                + (f', {connector.color}' if connector.color else ''))
                 bom_entries.append({
-                    'item': description, 'qty': 1, 'unit': '', 'designators': connector.name if connector.show_name else None,
+                    'item': description, 'qty': 1, 'unit': None, 'designators': connector.name if connector.show_name else None,
                     'manufacturer': connector.manufacturer, 'mpn': connector.mpn, 'pn': connector.pn
                 })
 

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -111,7 +111,7 @@ class Harness:
                             qty *= sum(1 for value in connector.visible_pins.values() if value is True)
                         else:
                             raise ValueError('invalid qty parameter {}'.format(extra["qty_multiplier"]))
-                    rows.append(html_line_breaks(component_table_entry(extra.get["type"], qty, extra.get("unit", None), extra.get("pn", None), extra.get("manufacturer", None), extra.get("mpn", None))))
+                    rows.append(html_line_breaks(component_table_entry(extra["type"], qty, extra.get("unit", None), extra.get("pn", None), extra.get("manufacturer", None), extra.get("mpn", None))))
             rows.append([html_line_breaks(connector.notes)])
             html.extend(nested_html_table(rows))
 

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -342,7 +342,7 @@ class Harness:
                 qty = extra.qty * component.get_qty_multiplier(extra.qty_multiplier)
                 if self.mini_bom_mode:
                     id = self.get_bom_index(extra.description, extra.unit, extra.manufacturer, extra.mpn, extra.pn)
-                    rows.append(component_table_entry(f'#{id} ({extra.type.capitalize().strip()})', qty, extra.unit))
+                    rows.append(component_table_entry(f'#{id} ({extra.type.rstrip()})', qty, extra.unit))
                 else:
                     rows.append(component_table_entry(extra.description, qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn))
         return(rows)

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -357,7 +357,6 @@ class Harness:
         for connector in self.connectors.values():
             if connector.additional_components:
                 for part in connector.additional_components:
-                    print(part)
                     if 'qty' in part:
                         if isinstance(part['qty'], int) or isinstance(part['qty'], float):
                             qty = part['qty']
@@ -372,12 +371,12 @@ class Harness:
                         qty = 1
                     connectors_extra.append(
                         {
-                            'type': part['type'] if 'type' in part else None,
+                            'type': part.get('type', None),
                             'qty': qty,
-                            'unit': part['unit'] if 'unit' in part else None,
-                            'manufacturer': part['manufacturer'] if 'manufacturer' in part else None,
-                            'mpn': part['mpn'] if 'mpn' in part else None,
-                            'pn': part['pn'] if 'pn' in part else None,
+                            'unit': part.get('unit', None),
+                            'manufacturer': part.get('manufacturer', None),
+                            'mpn': part.get('mpn', None),
+                            'pn': part.get('pn', None),
                             'designator': connector.name
                         }
                     )

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -418,7 +418,7 @@ class Harness:
 
         for item in self.additional_bom_items:
             bom_entries.append({
-                'item': item.get('description', ''), 'qty': item.get('qty'), 'unit': item.get('unit'), 'designators': item.get('designators'),
+                'item': item.get('description', ''), 'qty': item.get('qty', 1), 'unit': item.get('unit'), 'designators': item.get('designators'),
                 'manufacturer': item.get('manufacturer'), 'mpn': item.get('mpn'), 'pn': item.get('pn')
             })
 

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -365,7 +365,7 @@ class Harness:
                             if part['qty'] == 'pincount':
                                 qty = connector.pincount
                             elif part['qty'] == 'connectioncount':
-                                qty = connector.pincount
+                                qty = sum(1 for value in connector.visible_pins.values() if value is True)
                             else:
                                 raise ValueError('invalid aty parameter')
                     else:

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -99,8 +99,29 @@ class Harness:
                      connector.color, html_colorbar(connector.color)],
                     '<!-- connector table -->' if connector.style != 'simple' else None,
                     [html_image(connector.image)],
-                    [html_caption(connector.image)],
-                    [html_line_breaks(connector.notes)]]
+                    [html_caption(connector.image)]]
+            if connector.additional_components is not None:
+                rows.append(["Additional components"])
+            for extra in connector.additional_components:
+                if 'qty' in extra:
+                    if isinstance(extra['qty'], int) or isinstance(extra['qty'], float):
+                        qty = extra['qty']
+                    else:  # check for special quantities
+                        if extra['qty'] == 'pincount':
+                            qty = connector.pincount
+                        elif extra['qty'] == 'connectioncount':
+                            qty = sum(1 for value in connector.visible_pins.values() if value is True)
+                        else:
+                            raise ValueError('invalid aty parameter')
+                else:
+                    qty = 1
+                rows.append([extra["type"], qty])
+                rows.append([extra["manufacturer"],
+                             f'MPN: {extra["manufacturer_part_number"]}' if "manufacturer_part_number" in extra else None,
+                             f'IPN: {extra["internal_part_number"]}' if "internal_part_number" in extra else None],)
+                rows.append([f'P/N: {extra["pn"]}' if extra["pn"] else None,
+                             html_line_breaks(manufacturer_info_field(extra.get("manufacturer", None), extra.get("mpn", None)))])
+            rows.append([html_line_breaks(connector.notes)])
             html.extend(nested_html_table(rows))
 
             if connector.style != 'simple':

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -9,8 +9,7 @@ from wireviz.wv_helper import awg_equiv, mm2_equiv, tuplelist2tsv, \
     nested_html_table, flatten2d, index_if_list, html_line_breaks, \
     graphviz_line_breaks, remove_line_breaks, open_file_read, open_file_write, \
     html_colorbar, html_image, html_caption, manufacturer_info_field, \
-    component_table_entry, \
-    calculate_qty_multiplier_connector, calculate_qty_multiplier_cable
+    component_table_entry
 from collections import Counter
 from typing import List
 from pathlib import Path
@@ -107,12 +106,12 @@ class Harness:
             if connector.additional_components:
                 rows.append(["Additional components"])
                 for extra in connector.additional_components:
-                    qty = extra.qty * calculate_qty_multiplier_connector(extra.qty_multiplier, connector)
+                    qty = extra.qty * connector.get_qty_multiplier(extra.qty_multiplier)
                     if(self.mini_bom_mode):
-                        id = self.get_bom_index(extra.long_name(), extra.unit, extra.manufacturer, extra.mpn, extra.pn)
+                        id = self.get_bom_index(extra.description(), extra.unit, extra.manufacturer, extra.mpn, extra.pn)
                         rows.append(component_table_entry(f'{id} ({extra.type.capitalize()})', qty, extra.unit))
                     else:
-                        rows.append(component_table_entry(extra.long_name(), qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn))
+                        rows.append(component_table_entry(extra.description(), qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn))
             rows.append([html_line_breaks(connector.notes)])
             html.extend(nested_html_table(rows))
 
@@ -190,12 +189,12 @@ class Harness:
             if cable.additional_components:
                 rows.append(["Additional components"])
                 for extra in cable.additional_components:
-                    qty = extra.qty * calculate_qty_multiplier_cable(extra.qty_multiplier, cable)
+                    qty = extra.qty * cable.get_qty_multiplier(extra.qty_multiplier)
                     if(self.mini_bom_mode):
-                        id = self.get_bom_index(extra.long_name(), extra.unit, extra.manufacturer, extra.mpn, extra.pn)
+                        id = self.get_bom_index(extra.description(), extra.unit, extra.manufacturer, extra.mpn, extra.pn)
                         rows.append(component_table_entry(f'{id} ({extra.type.capitalize()})', qty, extra.unit))
                     else:
-                        rows.append(component_table_entry(extra.long_name(), qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn))
+                        rows.append(component_table_entry(extra.description(), qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn))
             rows.append([html_line_breaks(cable.notes)])
             html.extend(nested_html_table(rows))
 
@@ -371,10 +370,10 @@ class Harness:
                 bom_items.append(item)
 
             for part in connector.additional_components:
-                qty = part.qty * calculate_qty_multiplier_connector(part.qty_multiplier, connector)
+                qty = part.qty * connector.get_qty_multiplier(part.qty_multiplier)
                 bom_items.append(
                     {
-                        'item': part.long_name(),
+                        'item': part.description(),
                         'qty': qty,
                         'unit': part.unit,
                         'manufacturer': part.manufacturer,
@@ -409,10 +408,10 @@ class Harness:
                         bom_items.append(item)
 
             for part in cable.additional_components:
-                qty = part.qty * calculate_qty_multiplier_cable(part.qty_multiplier, cable)
+                qty = part.qty * cable.get_qty_multiplier(part.qty_multiplier)
                 bom_items.append(
                     {
-                        'item': part.long_name(),
+                        'item': part.description(),
                         'qty': qty,
                         'unit': part.unit,
                         'manufacturer': part.manufacturer,

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -403,7 +403,7 @@ class Harness:
                             'manufacturer': part.get('manufacturer', None),
                             'mpn': part.get('mpn', None),
                             'pn': part.get('pn', None),
-                            'designator': connector.name
+                            'designator': connector.name if connector.show_name else ''
                         }
                     )
         connector_extra_group = lambda ce: (ce['type'], ce['qty'], ce['unit'], ce['manufacturer'], ce['mpn'], ce['pn'])

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -108,10 +108,10 @@ class Harness:
                 for extra in connector.additional_components:
                     qty = extra.qty * connector.get_qty_multiplier(extra.qty_multiplier)
                     if(self.mini_bom_mode):
-                        id = self.get_bom_index(extra.description(), extra.unit, extra.manufacturer, extra.mpn, extra.pn)
+                        id = self.get_bom_index(extra.description, extra.unit, extra.manufacturer, extra.mpn, extra.pn)
                         rows.append(component_table_entry(f'{id} ({extra.type.capitalize()})', qty, extra.unit))
                     else:
-                        rows.append(component_table_entry(extra.description(), qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn))
+                        rows.append(component_table_entry(extra.description, qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn))
             rows.append([html_line_breaks(connector.notes)])
             html.extend(nested_html_table(rows))
 
@@ -191,10 +191,10 @@ class Harness:
                 for extra in cable.additional_components:
                     qty = extra.qty * cable.get_qty_multiplier(extra.qty_multiplier)
                     if(self.mini_bom_mode):
-                        id = self.get_bom_index(extra.description(), extra.unit, extra.manufacturer, extra.mpn, extra.pn)
+                        id = self.get_bom_index(extra.description, extra.unit, extra.manufacturer, extra.mpn, extra.pn)
                         rows.append(component_table_entry(f'{id} ({extra.type.capitalize()})', qty, extra.unit))
                     else:
-                        rows.append(component_table_entry(extra.description(), qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn))
+                        rows.append(component_table_entry(extra.description, qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn))
             rows.append([html_line_breaks(cable.notes)])
             html.extend(nested_html_table(rows))
 
@@ -373,7 +373,7 @@ class Harness:
                 qty = part.qty * connector.get_qty_multiplier(part.qty_multiplier)
                 bom_items.append(
                     {
-                        'item': part.description(),
+                        'item': part.description,
                         'qty': qty,
                         'unit': part.unit,
                         'manufacturer': part.manufacturer,
@@ -411,7 +411,7 @@ class Harness:
                 qty = part.qty * cable.get_qty_multiplier(part.qty_multiplier)
                 bom_items.append(
                     {
-                        'item': part.description(),
+                        'item': part.description,
                         'qty': qty,
                         'unit': part.unit,
                         'manufacturer': part.manufacturer,

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -9,7 +9,8 @@ from wireviz.wv_helper import awg_equiv, mm2_equiv, tuplelist2tsv, \
     nested_html_table, flatten2d, index_if_list, html_line_breaks, \
     graphviz_line_breaks, remove_line_breaks, open_file_read, open_file_write, \
     html_colorbar, html_image, html_caption, manufacturer_info_field, \
-    component_table_entry
+    component_table_entry, \
+    calculate_qty_multiplier_connector, calculate_qty_multiplier_cable
 from collections import Counter
 from typing import List
 from pathlib import Path
@@ -107,13 +108,7 @@ class Harness:
                 rows.append(["Additional components"])
                 for extra in connector.additional_components:
                     qty = extra.qty
-                    if extra.qty_multiplier:
-                        if extra.qty_multiplier == 'pincount':
-                            qty *= connector.pincount
-                        elif extra.qty_multiplier == 'populated':
-                            qty *= sum(connector.visible_pins.values())
-                        else:
-                            raise ValueError(f'invalid qty multiplier parameter {extra["qty_multiplier"]}')
+                    qty *= calculate_qty_multiplier_connector(extra.qty_multiplier, connector)
                     if(self.mini_bom_mode):
                         id = self.get_bom_index(extra.long_name(), extra.unit, extra.manufacturer, extra.mpn, extra.pn)
                         rows.append(html_line_breaks(component_table_entry(f'{id} ({extra.type.capitalize()})', qty, extra.unit)))
@@ -197,17 +192,7 @@ class Harness:
                 rows.append(["Additional components"])
                 for extra in cable.additional_components:
                     qty = extra.qty
-                    if extra.qty_multiplier:
-                        if extra.qty_multiplier == 'wirecount':
-                            qty *= cable.wirecount
-                        elif extra.qty_multiplier == 'terminations':
-                            qty *= len(cable.connections)
-                        elif extra.qty_multiplier == 'length':
-                            qty *= cable.length
-                        elif extra.qty_multiplier == 'total_length':
-                            qty *= cable.length * cable.wirecount
-                        else:
-                            raise ValueError(f'invalid qty multiplier parameter {extra["qty_multiplier"]}')
+                    qty *= calculate_qty_multiplier_cable(extra.qty_multiplier, cable)
                     if(self.mini_bom_mode):
                         id = self.get_bom_index(extra.long_name(), extra.unit, extra.manufacturer, extra.mpn, extra.pn)
                         rows.append(html_line_breaks(component_table_entry(f'{id} ({extra.type.capitalize()})', qty, extra.unit)))
@@ -389,13 +374,7 @@ class Harness:
 
             for part in connector.additional_components:
                 qty = part.qty
-                if part.qty_multiplier:
-                    if part.qty_multiplier == 'pincount':
-                        qty = connector.pincount
-                    elif part.qty_multiplier == 'populated':
-                        qty = sum(connector.visible_pins.values())
-                    else:
-                        raise ValueError(f'invalid qty multiplier parameter {part.qty_multiplier}')
+                qty *= calculate_qty_multiplier_connector(part.qty_multiplier, connector)
                 bom_items.append(
                     {
                         'item': part.long_name(),
@@ -434,17 +413,7 @@ class Harness:
 
             for part in cable.additional_components:
                 qty = part.qty
-                if part.qty_multiplier:
-                    if part.qty_multiplier == 'wirecount':
-                        qty *= cable.wirecount
-                    elif part.qty_multiplier == 'terminations':
-                        qty *= len(cable.connections)
-                    elif part.qty_multiplier == 'length':
-                        qty *= cable.length
-                    elif part.qty_multiplier == 'total_length':
-                        qty *= cable.length * cable.wirecount
-                    else:
-                        raise ValueError(f'invalid qty multiplier parameter {part.qty_multiplier}')
+                qty *= calculate_qty_multiplier_cable(part.qty_multiplier, cable)
                 bom_items.append(
                     {
                         'item': part.long_name(),

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -106,9 +106,9 @@ class Harness:
                     qty = extra.get('qty', 1)
                     if 'qty_multiplier' in extra:
                         if extra['qty_multiplier'] == 'pincount':
-                            qty = connector.pincount
+                            qty *= connector.pincount
                         elif extra['qty_multiplier'] == 'populated':
-                            qty = sum(1 for value in connector.visible_pins.values() if value is True)
+                            qty *= sum(1 for value in connector.visible_pins.values() if value is True)
                         else:
                             raise ValueError('invalid qty parameter {}'.format(extra["qty_multiplier'"]))
                     rows.append([extra["type"], f'{qty} {extra.get("unit", "")}'.strip()])

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -8,7 +8,7 @@ from wireviz.wv_colors import get_color_hex
 from wireviz.wv_helper import awg_equiv, mm2_equiv, tuplelist2tsv, \
     nested_html_table, flatten2d, index_if_list, html_line_breaks, \
     graphviz_line_breaks, remove_line_breaks, open_file_read, open_file_write, \
-    html_colorbar, html_image, html_caption, manufacturer_info_field
+    html_colorbar, html_image, html_caption, manufacturer_info_field, component_table_entry
 from collections import Counter
 from typing import List
 from pathlib import Path
@@ -110,10 +110,8 @@ class Harness:
                         elif extra['qty_multiplier'] == 'populated':
                             qty *= sum(1 for value in connector.visible_pins.values() if value is True)
                         else:
-                            raise ValueError('invalid qty parameter {}'.format(extra["qty_multiplier'"]))
-                    rows.append([extra["type"], f'{qty} {extra.get("unit", "")}'.strip()])
-                    rows.append([f'P/N: {extra["pn"]}' if "pn" in extra else None,
-                                 html_line_breaks(manufacturer_info_field(extra.get("manufacturer", None), extra.get("mpn", None)))])
+                            raise ValueError('invalid qty parameter {}'.format(extra["qty_multiplier"]))
+                    rows.append(html_line_breaks(component_table_entry(extra.get["type"], qty, extra.get("unit", None), extra.get("pn", None), extra.get("manufacturer", None), extra.get("mpn", None))))
             rows.append([html_line_breaks(connector.notes)])
             html.extend(nested_html_table(rows))
 
@@ -203,9 +201,7 @@ class Harness:
                             qty *= cable.length * cable.wirecount
                         else:
                             raise ValueError('invalid qty parameter {}'.format(extra["qty_multiplier"]))
-                    rows.append([extra["type"], f'{qty} {extra.get("unit", "")}'.strip()])
-                    rows.append([f'P/N: {extra["pn"]}' if "pn" in extra else None,
-                                 html_line_breaks(manufacturer_info_field(extra.get("manufacturer", None), extra.get("mpn", None)))])
+                    rows.append(html_line_breaks(component_table_entry(extra["type"], qty, extra.get("unit", None), extra.get("pn", None), extra.get("manufacturer", None), extra.get("mpn", None))))
             rows.append([html_line_breaks(cable.notes)])
             html.extend(nested_html_table(rows))
 

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -103,18 +103,14 @@ class Harness:
             if connector.additional_components is not None:
                 rows.append(["Additional components"])
                 for extra in connector.additional_components:
-                    if 'qty' in extra:
-                        if isinstance(extra['qty'], int) or isinstance(extra['qty'], float):
-                            qty = extra['qty']
-                        else:  # check for special quantities
-                            if extra['qty'] == 'pincount':
-                                qty = connector.pincount
-                            elif extra['qty'] == 'connectioncount':
-                                qty = sum(1 for value in connector.visible_pins.values() if value is True)
-                            else:
-                                raise ValueError('invalid qty parameter {}'.format(extra["qty"]))
-                    else:
-                        qty = 1
+                    qty = extra.get('qty', 1)
+                    if 'qty_multiplier' in extra:
+                        if extra['qty_multiplier'] == 'pincount':
+                            qty = connector.pincount
+                        elif extra['qty_multiplier'] == 'populated':
+                            qty = sum(1 for value in connector.visible_pins.values() if value is True)
+                        else:
+                            raise ValueError('invalid qty parameter {}'.format(extra["qty_multiplier'"]))
                     rows.append([extra["type"], f'{qty} {extra.get("unit", "")}'.strip()])
                     rows.append([f'P/N: {extra["pn"]}' if extra["pn"] else None,
                                  html_line_breaks(manufacturer_info_field(extra.get("manufacturer", None), extra.get("mpn", None)))])
@@ -195,22 +191,18 @@ class Harness:
             if cable.additional_components is not None:
                 rows.append(["Additional components"])
                 for extra in cable.additional_components:
-                    if 'qty' in extra:
-                        if isinstance(extra['qty'], int) or isinstance(extra['qty'], float):
-                            qty = extra['qty']
-                        else:  # check for special quantities
-                            if extra['qty'] == 'wirecount':
-                                qty = cable.wirecount
-                            elif extra['qty'] == 'terminations':
-                                qty = len(cable.connections)
-                            elif extra['qty'] == 'length':
-                                qty = cable.length
-                            elif extra['qty'] == 'total_length':
-                                qty = cable.length * cable.wirecount
-                            else:
-                                raise ValueError('invalid qty parameter {}'.format(extra["qty"]))
-                    else:
-                        qty = 1
+                    qty = extra.get('qty', 1)
+                    if 'qty_multiplier' in extra:
+                        if extra['qty_multiplier'] == 'wirecount':
+                            qty *= cable.wirecount
+                        elif extra['qty_multiplier'] == 'terminations':
+                            qty *= len(cable.connections)
+                        elif extra['qty_multiplier'] == 'length':
+                            qty *= cable.length
+                        elif extra['qty_multiplier'] == 'total_length':
+                            qty *= cable.length * cable.wirecount
+                        else:
+                            raise ValueError('invalid qty parameter {}'.format(extra["qty_multiplier"]))
                     rows.append([extra["type"], f'{qty} {extra.get("unit", "")}'.strip()])
                     rows.append([f'P/N: {extra["pn"]}' if extra["pn"] else None,
                                  html_line_breaks(manufacturer_info_field(extra.get("manufacturer", None), extra.get("mpn", None)))])
@@ -399,18 +391,14 @@ class Harness:
         for connector in self.connectors.values():
             if connector.additional_components:
                 for part in connector.additional_components:
-                    if 'qty' in part:
-                        if isinstance(part['qty'], int) or isinstance(part['qty'], float):
-                            qty = part['qty']
-                        else:  # check for special quantities
-                            if part['qty'] == 'pincount':
-                                qty = connector.pincount
-                            elif part['qty'] == 'connectioncount':
-                                qty = sum(1 for value in connector.visible_pins.values() if value is True)
-                            else:
-                                raise ValueError('invalid aty parameter')
-                    else:
-                        qty = 1
+                    qty = part.get('qty', 1)
+                    if 'qty_multiplier' in part:
+                        if part['qty_multiplier'] == 'pincount':
+                            qty = connector.pincount
+                        elif part['qty_multiplier'] == 'populated':
+                            qty = sum(1 for value in connector.visible_pins.values() if value is True)
+                        else:
+                            raise ValueError('invalid qty parameter {}'.format(part["qty_multiplier'"]))
                     connectors_extra.append(
                         {
                             'type': part.get('type', None),
@@ -488,22 +476,18 @@ class Harness:
         for cable in self.cables.values():
             if cable.additional_components:
                 for part in cable.additional_components:
-                    if 'qty' in part:
-                        if isinstance(part['qty'], int) or isinstance(part['qty'], float):
-                            qty = part['qty']
-                        else:  # check for special quantities
-                            if part['qty'] == 'wirecount':
-                                qty = cable.wirecount
-                            elif part['qty'] == 'terminations':
-                                qty = len(cable.connections)
-                            elif part['qty'] == 'length':
-                                qty = cable.length
-                            elif part['qty'] == 'total_length':
-                                qty = cable.length * cable.wirecount
-                            else:
-                                raise ValueError('invalid aty parameter')
-                    else:
-                        qty = 1
+                    qty = part.get('qty', 1)
+                    if 'qty_multiplier' in part:
+                        if part['qty_multiplier'] == 'wirecount':
+                            qty *= cable.wirecount
+                        elif part['qty_multiplier'] == 'terminations':
+                            qty *= len(cable.connections)
+                        elif part['qty_multiplier'] == 'length':
+                            qty *= cable.length
+                        elif part['qty_multiplier'] == 'total_length':
+                            qty *= cable.length * cable.wirecount
+                        else:
+                            raise ValueError('invalid qty parameter {}'.format(part["qty_multiplier"]))
                     cables_extra.append(
                         {
                             'type': part.get('type', None),

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -104,16 +104,15 @@ class Harness:
                     '<!-- connector table -->' if connector.style != 'simple' else None,
                     [html_image(connector.image)],
                     [html_caption(connector.image)]]
-            if connector.additional_components is not None:
+            if connector.additional_components:
                 rows.append(["Additional components"])
                 for extra in connector.additional_components:
-                    qty = extra.qty
-                    qty *= calculate_qty_multiplier_connector(extra.qty_multiplier, connector)
+                    qty = extra.qty * calculate_qty_multiplier_connector(extra.qty_multiplier, connector)
                     if(self.mini_bom_mode):
                         id = self.get_bom_index(extra.long_name(), extra.unit, extra.manufacturer, extra.mpn, extra.pn)
-                        rows.append(html_line_breaks(component_table_entry(f'{id} ({extra.type.capitalize()})', qty, extra.unit)))
+                        rows.append(component_table_entry(f'{id} ({extra.type.capitalize()})', qty, extra.unit))
                     else:
-                        rows.append(html_line_breaks(extra.long_name(), qty, extra.get.unit, extra.pn, extra.manufacturer, extra.mpn))
+                        rows.append(component_table_entry(extra.long_name(), qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn))
             rows.append([html_line_breaks(connector.notes)])
             html.extend(nested_html_table(rows))
 
@@ -188,16 +187,15 @@ class Harness:
                     [html_image(cable.image)],
                     [html_caption(cable.image)]]
 
-            if len(cable.additional_components) > 0:
+            if cable.additional_components:
                 rows.append(["Additional components"])
                 for extra in cable.additional_components:
-                    qty = extra.qty
-                    qty *= calculate_qty_multiplier_cable(extra.qty_multiplier, cable)
+                    qty = extra.qty * calculate_qty_multiplier_cable(extra.qty_multiplier, cable)
                     if(self.mini_bom_mode):
                         id = self.get_bom_index(extra.long_name(), extra.unit, extra.manufacturer, extra.mpn, extra.pn)
-                        rows.append(html_line_breaks(component_table_entry(f'{id} ({extra.type.capitalize()})', qty, extra.unit)))
+                        rows.append(component_table_entry(f'{id} ({extra.type.capitalize()})', qty, extra.unit))
                     else:
-                        rows.append(html_line_breaks(component_table_entry(extra.long_name(), qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn)))
+                        rows.append(component_table_entry(extra.long_name(), qty, extra.unit, extra.pn, extra.manufacturer, extra.mpn))
             rows.append([html_line_breaks(cable.notes)])
             html.extend(nested_html_table(rows))
 
@@ -356,7 +354,7 @@ class Harness:
 
     def bom(self):
         # if the bom has previously been generated then return the generated bom
-        if len(self._bom) > 0:
+        if self._bom:
             return self._bom
         bom_items = []
 
@@ -373,8 +371,7 @@ class Harness:
                 bom_items.append(item)
 
             for part in connector.additional_components:
-                qty = part.qty
-                qty *= calculate_qty_multiplier_connector(part.qty_multiplier, connector)
+                qty = part.qty * calculate_qty_multiplier_connector(part.qty_multiplier, connector)
                 bom_items.append(
                     {
                         'item': part.long_name(),
@@ -404,16 +401,15 @@ class Harness:
                 else:
                     # add each wire from the bundle to the bom
                     for index, color in enumerate(cable.colors, 0):
-                        gauge_color = f', {color}' if color else ''
-                        name = f'Wire{cable_type}{gauge_name}{gauge_color}'
+                        wire_color = f', {color}' if color else ''
+                        name = f'Wire{cable_type}{gauge_name}{wire_color}'
                         item = {'item': name, 'qty': cable.length, 'unit': 'm', 'designators': cable.name,
                                 'manufacturer': remove_line_breaks(index_if_list(cable.manufacturer, index)),
                                 'mpn': remove_line_breaks(index_if_list(cable.mpn, index)), 'pn': index_if_list(cable.pn, index)}
                         bom_items.append(item)
 
             for part in cable.additional_components:
-                qty = part.qty
-                qty *= calculate_qty_multiplier_cable(part.qty_multiplier, cable)
+                qty = part.qty * calculate_qty_multiplier_cable(part.qty_multiplier, cable)
                 bom_items.append(
                     {
                         'item': part.long_name(),
@@ -427,8 +423,7 @@ class Harness:
                 )
 
         for item in self.additional_bom_items:
-            name = item['description'] if item.get('description', None) else ''
-            item = {'item': name, 'qty': item.get('qty'), 'unit': item.get('unit'), 'designators': item.get('designators'),
+            item = {'item': item.get('description', ''), 'qty': item.get('qty'), 'unit': item.get('unit'), 'designators': item.get('designators'),
                     'manufacturer': item.get('manufacturer'), 'mpn': item.get('mpn'), 'pn': item.get('pn')}
             bom_items.append(item)
 

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -336,7 +336,7 @@ class Harness:
         bom_extra = []
         # connectors
         connector_group = lambda c: (c.type, c.subtype, c.pincount, c.manufacturer, c.mpn, c.pn)
-        for group in Counter([connector_group(v) for v in self.connectors.values()]):
+        for group in Counter([connector_group(v) for v in self.connectors.values() if v.ignore_in_bom is not True]):
             items = {k: v for k, v in self.connectors.items() if connector_group(v) == group}
             shared = next(iter(items.values()))
             designators = list(items.keys())
@@ -355,7 +355,7 @@ class Harness:
         # TODO: If category can have other non-empty values than 'bundle', maybe it should be part of item name?
         # The category needs to be included in cable_group to keep the bundles excluded.
         cable_group = lambda c: (c.category, c.type, c.gauge, c.gauge_unit, c.wirecount, c.shield, c.manufacturer, c.mpn, c.pn)
-        for group in Counter([cable_group(v) for v in self.cables.values() if v.category != 'bundle']):
+        for group in Counter([cable_group(v) for v in self.cables.values() if v.category != 'bundle' and v.ignore_in_bom is not True]):
             items = {k: v for k, v in self.cables.items() if cable_group(v) == group}
             shared = next(iter(items.values()))
             designators = list(items.keys())

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -7,9 +7,8 @@ from wireviz import wv_colors, wv_helper, __version__, APP_NAME, APP_URL
 from wireviz.wv_colors import get_color_hex
 from wireviz.wv_helper import awg_equiv, mm2_equiv, tuplelist2tsv, \
     nested_html_table, flatten2d, index_if_list, html_line_breaks, \
-    graphviz_line_breaks, remove_line_breaks, clean_whitespace, open_file_read, \
-    open_file_write, html_colorbar, html_image, html_caption, \
-    manufacturer_info_field, component_table_entry
+    clean_whitespace, open_file_read, open_file_write, html_colorbar, \
+    html_image, html_caption, manufacturer_info_field, component_table_entry
 from collections import Counter
 from typing import List, Union
 from pathlib import Path
@@ -451,7 +450,7 @@ class Harness:
         # Remove linebreaks and clean whitespace of values in search
         target = tuple(clean_whitespace(v) for v in (item, unit, manufacturer, mpn, pn))
         for entry in self.bom():
-            if(entry['item'], entry['unit'], entry['manufacturer'], entry['mpn'], entry['pn']) == target:
+            if (entry['item'], entry['unit'], entry['manufacturer'], entry['mpn'], entry['pn']) == target:
                 return entry['id']
         return None
 

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -496,7 +496,7 @@ class Harness:
                             'manufacturer': part.get('manufacturer', None),
                             'mpn': part.get('mpn', None),
                             'pn': part.get('pn', None),
-                            'designator': connector.name
+                            'designator': cable.name
                         }
                     )
         cables_extra_group = lambda ce: (ce['type'], ce['qty'], ce['unit'], ce['manufacturer'], ce['mpn'], ce['pn'])

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -112,10 +112,10 @@ class Harness:
                             elif extra['qty'] == 'connectioncount':
                                 qty = sum(1 for value in connector.visible_pins.values() if value is True)
                             else:
-                                raise ValueError('invalid aty parameter')
+                                raise ValueError('invalid qty parameter {}'.format(extra["qty"]))
                     else:
                         qty = 1
-                    rows.append([extra["type"], qty])
+                    rows.append([extra["type"], f'{qty} {extra.get("unit", "")}'.strip()])
                     rows.append([f'P/N: {extra["pn"]}' if extra["pn"] else None,
                                  html_line_breaks(manufacturer_info_field(extra.get("manufacturer", None), extra.get("mpn", None)))])
             rows.append([html_line_breaks(connector.notes)])
@@ -208,10 +208,10 @@ class Harness:
                             elif extra['qty'] == 'total_length':
                                 qty = cable.length * cable.wirecount
                             else:
-                                raise ValueError('invalid aty parameter {}'.format(extra["qty"]))
+                                raise ValueError('invalid qty parameter {}'.format(extra["qty"]))
                     else:
                         qty = 1
-                    rows.append([extra["type"], qty])
+                    rows.append([extra["type"], f'{qty} {extra.get("unit", "")}'.strip()])
                     rows.append([f'P/N: {extra["pn"]}' if extra["pn"] else None,
                                  html_line_breaks(manufacturer_info_field(extra.get("manufacturer", None), extra.get("mpn", None)))])
             rows.append([html_line_breaks(cable.notes)])

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -112,7 +112,7 @@ class Harness:
                         else:
                             raise ValueError('invalid qty parameter {}'.format(extra["qty_multiplier'"]))
                     rows.append([extra["type"], f'{qty} {extra.get("unit", "")}'.strip()])
-                    rows.append([f'P/N: {extra["pn"]}' if extra["pn"] else None,
+                    rows.append([f'P/N: {extra["pn"]}' if "pn" in extra else None,
                                  html_line_breaks(manufacturer_info_field(extra.get("manufacturer", None), extra.get("mpn", None)))])
             rows.append([html_line_breaks(connector.notes)])
             html.extend(nested_html_table(rows))
@@ -204,7 +204,7 @@ class Harness:
                         else:
                             raise ValueError('invalid qty parameter {}'.format(extra["qty_multiplier"]))
                     rows.append([extra["type"], f'{qty} {extra.get("unit", "")}'.strip()])
-                    rows.append([f'P/N: {extra["pn"]}' if extra["pn"] else None,
+                    rows.append([f'P/N: {extra["pn"]}' if "pn" in extra else None,
                                  html_line_breaks(manufacturer_info_field(extra.get("manufacturer", None), extra.get("mpn", None)))])
             rows.append([html_line_breaks(cable.notes)])
             html.extend(nested_html_table(rows))

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -197,6 +197,7 @@ def component_table_entry(type, qty, unit=None, pn=None, manufacturer=None, mpn=
                 output += ', '
         if manufacturer_str:
             output += manufacturer_str
+    output = html_line_breaks(output)
     # format the above output as left aligned text in a single visable cell
     return f'<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr><td align="left" balign="left">{output}</td></tr></table>'
 

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -200,3 +200,9 @@ def component_table_entry(type, qty, unit=None, pn=None, manufacturer=None, mpn=
     # format the above output as left aligned text in a single visable cell
     output = f'<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr><td align="left" balign="left">{output}</td></tr></table>'
     return output
+
+
+def extra_component_long_name(type, subtype):
+    name_subtype = f', {remove_line_breaks(subtype)}' if subtype else ''
+    name = f'{type.capitalize()}{name_subtype}'
+    return name

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -146,12 +146,6 @@ def index_if_list(value, index):
 def html_line_breaks(inp):
     return inp.replace('\n', '<br />') if isinstance(inp, str) else inp
 
-def graphviz_line_breaks(inp):
-    return inp.replace('\n', '\\n') if isinstance(inp, str) else inp # \n generates centered new lines. http://www.graphviz.org/doc/info/attrs.html#k:escString
-
-def remove_line_breaks(inp):
-    return inp.replace('\n', ' ').strip() if isinstance(inp, str) else inp
-
 def clean_whitespace(inp):
     return ' '.join(inp.split()).replace(' ,', ',') if isinstance(inp, str) else inp
 
@@ -202,4 +196,7 @@ def component_table_entry(type, qty, unit=None, pn=None, manufacturer=None, mpn=
             output += manufacturer_str
     output = html_line_breaks(output)
     # format the above output as left aligned text in a single visible cell
-    return f'<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr><td align="left" balign="left">{output}</td></tr></table>'
+    # indent is set to two to match the indent in the generated html table
+    return f'''<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr>
+   <td align="left" balign="left">{output}</td>
+  </tr></table>'''

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -200,31 +200,3 @@ def component_table_entry(type, qty, unit=None, pn=None, manufacturer=None, mpn=
     output = html_line_breaks(output)
     # format the above output as left aligned text in a single visable cell
     return f'<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr><td align="left" balign="left">{output}</td></tr></table>'
-
-
-def calculate_qty_multiplier_connector(qty_multiplier, connector):
-    if not qty_multiplier:
-        return 1
-
-    if qty_multiplier == 'pincount':
-        return connector.pincount
-    elif qty_multiplier == 'populated':
-        return sum(connector.visible_pins.values())
-    else:
-        raise ValueError(f'invalid qty multiplier parameter for connector {qty_multiplier}')
-
-
-def calculate_qty_multiplier_cable(qty_multiplier, cable):
-    if not qty_multiplier:
-        return 1
-
-    if qty_multiplier == 'wirecount':
-        return cable.wirecount
-    elif qty_multiplier == 'terminations':
-        return len(cable.connections)
-    elif qty_multiplier == 'length':
-        return cable.length
-    elif qty_multiplier == 'total_length':
-        return cable.length * cable.wirecount
-    else:
-        raise ValueError(f'invalid qty multiplier parameter for cable {qty_multiplier}')

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -198,5 +198,32 @@ def component_table_entry(type, qty, unit=None, pn=None, manufacturer=None, mpn=
         if manufacturer_str:
             output += manufacturer_str
     # format the above output as left aligned text in a single visable cell
-    output = f'<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr><td align="left" balign="left">{output}</td></tr></table>'
-    return output
+    return f'<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr><td align="left" balign="left">{output}</td></tr></table>'
+
+
+def calculate_qty_multiplier_connector(qty_multiplier, connector):
+    if not qty_multiplier:
+        return 1
+
+    if qty_multiplier == 'pincount':
+        return connector.pincount
+    elif qty_multiplier == 'populated':
+        return sum(connector.visible_pins.values())
+    else:
+        raise ValueError(f'invalid qty multiplier parameter for connector {qty_multiplier}')
+
+
+def calculate_qty_multiplier_cable(qty_multiplier, cable):
+    if not qty_multiplier:
+        return 1
+
+    if qty_multiplier == 'wirecount':
+        return cable.wirecount
+    elif qty_multiplier == 'terminations':
+        return len(cable.connections)
+    elif qty_multiplier == 'length':
+        return cable.length
+    elif qty_multiplier == 'total_length':
+        return cable.length * cable.wirecount
+    else:
+        raise ValueError(f'invalid qty multiplier parameter for cable {qty_multiplier}')

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -181,3 +181,22 @@ def manufacturer_info_field(manufacturer, mpn):
         return f'{manufacturer if manufacturer else "MPN"}{": " + str(mpn) if mpn else ""}'
     else:
         return None
+
+def component_table_entry(type, qty, unit=None, pn=None, manufacturer=None, mpn=None):
+    output = f'{qty}'
+    if unit:
+        output += f' {unit}'
+    output += f' x {type}'
+    # print an extra line with part and manufacturer information if provided
+    manufacturer_str = manufacturer_info_field(manufacturer, mpn)
+    if pn or manufacturer_str:
+        output += '<br/>'
+        if pn:
+            output += f'P/N: {pn}'
+            if manufacturer_str:
+                output += ', '
+        if manufacturer_str:
+            output += manufacturer_str
+    # format the above output as left aligned text in a single visable cell
+    output = f'<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr><td align="left" balign="left">{output}</td></tr></table>'
+    return output

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -198,5 +198,5 @@ def component_table_entry(type, qty, unit=None, pn=None, manufacturer=None, mpn=
         if manufacturer_str:
             output += manufacturer_str
     output = html_line_breaks(output)
-    # format the above output as left aligned text in a single visable cell
+    # format the above output as left aligned text in a single visible cell
     return f'<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr><td align="left" balign="left">{output}</td></tr></table>'

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -200,9 +200,3 @@ def component_table_entry(type, qty, unit=None, pn=None, manufacturer=None, mpn=
     # format the above output as left aligned text in a single visable cell
     output = f'<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr><td align="left" balign="left">{output}</td></tr></table>'
     return output
-
-
-def extra_component_long_name(type, subtype):
-    name_subtype = f', {remove_line_breaks(subtype)}' if subtype else ''
-    name = f'{type.capitalize()}{name_subtype}'
-    return name

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -152,6 +152,9 @@ def graphviz_line_breaks(inp):
 def remove_line_breaks(inp):
     return inp.replace('\n', ' ').strip() if isinstance(inp, str) else inp
 
+def clean_whitespace(inp):
+    return ' '.join(inp.split()).replace(' ,', ',') if isinstance(inp, str) else inp
+
 def open_file_read(filename):
     # TODO: Intelligently determine encoding
     return open(filename, 'r', encoding='UTF-8')

--- a/tutorial/tutorial08.md
+++ b/tutorial/tutorial08.md
@@ -1,6 +1,7 @@
-## Part numbers
+## Part numbers and additional components
 
 * Part number information can be added to parts
   * Only provided fields will be added to the diagram and bom
 * Bundles can have part information specified by wire
-* Additional parts can be added to the bom
+* Additional parts can be added to components or just to the bom
+  * quantities of additional components can be multiplied by features from parent connector or cable

--- a/tutorial/tutorial08.yml
+++ b/tutorial/tutorial08.yml
@@ -5,9 +5,17 @@ connectors:
     subtype: female
     manufacturer: Molex # set manufacter name
     mpn: 22013047 # set manufacturer part number
+    # add a list of additional components to a part (shown in graph)
+    additional_components:
+      -
+        type: Crimp # short identifier used in graph
+        subtype: Molex KK 254, 22-30 AWG # extra information added to type in bom
+        qty_multiplier: populated # multipier for quantity (number of populated pins)
+        manufacturer: Molex # set manufacter name
+        mpn: 08500030 # set manufacturer part number
   X2:
     <<: *template1 # reuse template
-    pn: CON4 # set an internal part number
+    pn: CON4 # set an internal part number for just this connector
   X3:
     <<: *template1 # reuse template
 
@@ -28,6 +36,14 @@ cables:
     manufacturer: [WiresCo,WiresCo,WiresCo,WiresCo] # set a manufacter per wire
     mpn: [W1-YE,W1-BK,W1-BK,W1-RD]
     pn: [WIRE1,WIRE2,WIRE2,WIRE3]
+    # add a list of additional components to a part (shown in graph)
+    additional_components:
+      -
+        type: Sleve # short identifier used in graph
+        subtype: Braided nylon, black, 3mm # extra information added to type in bom
+        qty_multiplier: length # multipier for quantity (length of cable)
+        unit: m
+        pn: SLV-1
 
 
 connections:
@@ -41,7 +57,7 @@ connections:
     - X3: [1-4]
 
 additional_bom_items:
-  - # define an additional item to add to the bill of materials
+  - # define an additional item to add to the bill of materials (does not appear in graph)
     description: Label, pinout information
     qty: 2
     designators:


### PR DESCRIPTION
Draft implementation of #50.

An exmple file to work with this is shown below.

```yaml
connectors:
  X1:
    type: Powerpole
    pinout: [GND, VCC]
    ignore_in_bom: true
    additional_components:
      -
        type: housing
        qty: 1
        unit: ea
        manufacturer: Anderson
        manufacturer_part_number: 1327G6
        internal_part_number: powerpole-black
      -
        type: housing
        qty: 1
        unit: ea
        manufacturer: Anderson
        manufacturer_part_number: 1327
        internal_part_number: powerpole-red
      -
        type: crimp
        qty: pincount
        unit: ea
        manufacturer: Anderson
        manufacturer_part_number: 1331
        internal_part_number: powerpole-crimp-30A
  X2: &mf3-5
    type: Molex Micro-Fit
    subtype: female
    pinout: [GND, VCC, A, B, C]
    manufacturer_part_number: 436450500
    manufacturer: Molex
    internal_part_number: MF3.0-5
    additional_components:
      -
        type: crimp
        qty: connectioncount
        unit: ea
        manufacturer: Molex
        manufacturer_part_number: 43030-0007
        internal_part_number: MF3.0-Crimp

  X3:
    <<: *mf3-5

cables:
  W1: &wire_power # define template
    colors: [BK, RD] # number of wires implicit in color list
    gauge: 0.25 # assume mm2 if no gauge unit is specified
    show_equiv: true
    length: 0.2
    manufacturer_part_number: 123456

  W2:
    <<: *wire_power

connections:
  -
    - X1: [1-2]
    - W1: [1-2]
    - X2: [1-2]
  -
    - X1: [1-2]
    - W2: [1-2]
    - X3: [1-2]
```