### PR TITLE
Extended build examples

### DIFF
--- a/src/wireviz/build_examples.py
+++ b/src/wireviz/build_examples.py
@@ -14,17 +14,24 @@ from wv_helper import open_file_write, open_file_read, open_file_append
 
 
 readme = 'readme.md'
-groups = {}
-groups['examples'] = {'path': Path(script_path).parent.parent.parent / 'examples',
-                     'prefix': 'ex',
-                     readme: [], # Include no files
-                     'title': 'Example Gallery'}
-groups['tutorial'] = {'path': Path(script_path).parent.parent.parent / 'tutorial',
-                     'prefix': 'tutorial',
-                     readme: ['md', 'yml'], # Include .md and .yml files
-                     'title': 'WireViz Tutorial'}
-groups['demos']    = {'path': Path(script_path).parent.parent.parent / 'examples',
-                     'prefix': 'demo'}
+groups = {
+    'examples': {
+        'path': Path(script_path).parent.parent.parent / 'examples',
+        'prefix': 'ex',
+        readme: [], # Include no files
+        'title': 'Example Gallery',
+    },
+    'tutorial' : {
+        'path': Path(script_path).parent.parent.parent / 'tutorial',
+        'prefix': 'tutorial',
+        readme: ['md', 'yml'], # Include .md and .yml files
+        'title': 'WireViz Tutorial',
+    },
+    'demos' : {
+        'path': Path(script_path).parent.parent.parent / 'examples',
+        'prefix': 'demo',
+    },
+}
 
 input_extensions = ['.yml']
 generated_extensions = ['.gv', '.png', '.svg', '.html', '.bom.tsv']

--- a/src/wireviz/build_examples.py
+++ b/src/wireviz/build_examples.py
@@ -125,6 +125,8 @@ def parse_args():
     parser.add_argument('action', nargs='?', action='store',
                         choices=['build','clean','compare','restore'], default='build',
                         help='what to do with the generated files (default: build)')
+    parser.add_argument('-c', '--compare-graphviz-output', action='store_true',
+                        help='the Graphviz output is also compared (default: False)')
     parser.add_argument('-g', '--groups', nargs='+',
                         choices=groups.keys(), default=groups.keys(),
                         help='the groups of generated files (default: all)')
@@ -138,7 +140,7 @@ def main():
     elif args.action == 'clean':
         clean_generated(args.groups)
     elif args.action == 'compare':
-        compare_generated(args.groups)
+        compare_generated(args.groups, args.compare_graphviz_output)
     elif args.action == 'restore':
         restore_generated(args.groups)
 

--- a/src/wireviz/build_examples.py
+++ b/src/wireviz/build_examples.py
@@ -13,56 +13,59 @@ from wireviz import wireviz
 from wv_helper import open_file_write, open_file_read, open_file_append
 
 
-paths = {}
-paths['examples'] = {'path': Path(script_path).parent.parent.parent / 'examples',
+readme = 'readme.md'
+groups = {}
+groups['examples'] = {'path': Path(script_path).parent.parent.parent / 'examples',
                      'prefix': 'ex',
+                     readme: [], # Include no files
                      'title': 'Example Gallery'}
-paths['tutorial'] = {'path': Path(script_path).parent.parent.parent / 'tutorial',
+groups['tutorial'] = {'path': Path(script_path).parent.parent.parent / 'tutorial',
                      'prefix': 'tutorial',
+                     readme: ['md', 'yml'], # Include .md and .yml files
                      'title': 'WireViz Tutorial'}
-paths['demos']    = {'path': Path(script_path).parent.parent.parent / 'examples',
+groups['demos']    = {'path': Path(script_path).parent.parent.parent / 'examples',
                      'prefix': 'demo'}
 
 input_extensions = ['.yml']
 generated_extensions = ['.gv', '.png', '.svg', '.html', '.bom.tsv']
 extensions_not_from_graphviz = [ext for ext in generated_extensions if ext[-1] == 'v']
-readme = 'readme.md'
 
 
-def collect_filenames(description, pathkey, ext_list, extrafile = None):
-    path = paths[pathkey]['path']
-    patterns = [f"{paths[pathkey]['prefix']}*{ext}" for ext in ext_list]
-    if extrafile is not None:
-        patterns.append(extrafile)
-    print(f"{description} {path}")
+def collect_filenames(description, groupkey, ext_list):
+    path = groups[groupkey]['path']
+    patterns = [f"{groups[groupkey]['prefix']}*{ext}" for ext in ext_list]
+    if ext_list != input_extensions and readme in groups[groupkey]:
+        patterns.append(readme)
+    print(f"{description} {groupkey} in {path}")
     return sorted([filename for pattern in patterns for filename in path.glob(pattern)])
 
 
-def build(dirname, build_readme, include_source, include_readme):
+def build_generated(groupkey):
     # build files
-    path = paths[dirname]['path']
+    path = groups[groupkey]['path']
+    build_readme = readme in groups[groupkey]
     if build_readme:
-        with open_file_write(path / 'readme.md') as out:
-            out.write(f'# {paths[dirname]["title"]}\n\n')
+        include_readme = 'md' in groups[groupkey][readme]
+        include_source = 'yml' in groups[groupkey][readme]
+        with open_file_write(path / readme) as out:
+            out.write(f'# {groups[groupkey]["title"]}\n\n')
     # collect and iterate input YAML files
-    for yaml_file in collect_filenames('Building', dirname, input_extensions):
+    for yaml_file in collect_filenames('Building', groupkey, input_extensions):
         print(f'  {yaml_file}')
         wireviz.parse_file(yaml_file)
 
         if build_readme:
             i = ''.join(filter(str.isdigit, yaml_file.stem))
 
-            if include_readme:
-                with open_file_append(path / readme) as out:
-                    with open_file_read(path / f'{yaml_file.stem}.md') as info:
+            with open_file_append(path / readme) as out:
+                if include_readme:
+                    with open_file_read(yaml_file.with_suffix('.md')) as info:
                         for line in info:
-                            out.write(line.replace('## ', '## {} - '.format(i)))
+                            out.write(line.replace('## ', f'## {i} - '))
                         out.write('\n\n')
-            else:
-                with open_file_append(path / readme) as out:
+                else:
                     out.write(f'## Example {i}\n')
 
-            with open_file_append(path / readme) as out:
                 if include_source:
                     with open_file_read(yaml_file) as src:
                         out.write('```yaml\n')
@@ -75,32 +78,33 @@ def build(dirname, build_readme, include_source, include_readme):
                 out.write(f'[Source]({yaml_file.name}) - [Bill of Materials]({yaml_file.stem}.bom.tsv)\n\n\n')
 
 
-def clean_examples():
-    for key in paths.keys():
+def clean_generated(groupkeys):
+    for key in groupkeys:
         # collect and remove files
-        for filename in collect_filenames('Cleaning', key, generated_extensions, readme):
+        for filename in collect_filenames('Cleaning', key, generated_extensions):
             if filename.is_file():
                 print(f'  rm {filename}')
                 os.remove(filename)
 
 
-def compare_generated(include_from_graphviz = False):
+def compare_generated(groupkeys, include_from_graphviz = False):
     compare_extensions = generated_extensions if include_from_graphviz else extensions_not_from_graphviz
-    for key in paths.keys():
+    for key in groupkeys:
         # collect and compare files
-        for filename in collect_filenames('Comparing', key, compare_extensions, readme):
+        for filename in collect_filenames('Comparing', key, compare_extensions):
             cmd = f'git --no-pager diff {filename}'
             print(f'  {cmd}')
             os.system(cmd)
 
 
-def restore_generated():
-    for key, value in paths.items():
+def restore_generated(groupkeys):
+    for key in groupkeys:
         # collect input YAML files
         filename_list = collect_filenames('Restoring', key, input_extensions)
         # collect files to restore
         filename_list = [fn.with_suffix(ext) for fn in filename_list for ext in generated_extensions]
-        filename_list.append(value['path'] / readme)
+        if readme in groups[key]:
+            filename_list.append(groups[key]['path'] / readme)
         # restore files
         for filename in filename_list:
             cmd = f'git checkout -- {filename}'
@@ -110,27 +114,27 @@ def restore_generated():
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Wireviz Example Manager',)
-    parser.add_argument('action', nargs='?', action='store', default='build')
-    parser.add_argument('-generate', nargs='*', choices=['examples', 'demos', 'tutorial'], default=['examples', 'demos', 'tutorial'])
+    parser.add_argument('action', nargs='?', action='store',
+                        choices=['build','clean','compare','restore'], default='build',
+                        help='what to do with the generated files (default: build)')
+    parser.add_argument('-g', '--groups', nargs='+',
+                        choices=groups.keys(), default=groups.keys(),
+                        help='the groups of generated files (default: all)')
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
     if args.action == 'build':
-        for gentype in args.generate:
-            if gentype == 'demos':
-                build('demos', build_readme = False, include_source = False, include_readme = False)
-            if gentype == 'examples':
-                build('examples', build_readme = True, include_source = False, include_readme = False)
-            if gentype == 'tutorial':
-                build('tutorial', build_readme = True, include_source = True, include_readme = True)
+        # TODO: Move this loop into the function for consistency?
+        for groupkey in args.groups:
+            build_generated(groupkey)
     elif args.action == 'clean':
-        clean_examples()
+        clean_generated(args.groups)
     elif args.action == 'compare':
-        compare_generated()
+        compare_generated(args.groups)
     elif args.action == 'restore':
-        restore_generated()
+        restore_generated(args.groups)
 
 
 if __name__ == '__main__':

--- a/src/wireviz/build_examples.py
+++ b/src/wireviz/build_examples.py
@@ -34,8 +34,9 @@ groups = {
 }
 
 input_extensions = ['.yml']
-generated_extensions = ['.gv', '.png', '.svg', '.html', '.bom.tsv']
-extensions_not_from_graphviz = [ext for ext in generated_extensions if ext[-1] == 'v']
+extensions_not_containing_graphviz_output = ['.gv', '.bom.tsv']
+extensions_containing_graphviz_output = ['.png', '.svg', '.html']
+generated_extensions = extensions_not_containing_graphviz_output + extensions_containing_graphviz_output
 
 
 def collect_filenames(description, groupkey, ext_list):
@@ -43,7 +44,7 @@ def collect_filenames(description, groupkey, ext_list):
     patterns = [f"{groups[groupkey]['prefix']}*{ext}" for ext in ext_list]
     if ext_list != input_extensions and readme in groups[groupkey]:
         patterns.append(readme)
-    print(f"{description} {groupkey} in {path}")
+    print(f'{description} {groupkey} in "{path}"')
     return sorted([filename for pattern in patterns for filename in path.glob(pattern)])
 
 
@@ -59,7 +60,7 @@ def build_generated(groupkeys):
                 out.write(f'# {groups[key]["title"]}\n\n')
         # collect and iterate input YAML files
         for yaml_file in collect_filenames('Building', key, input_extensions):
-            print(f'  {yaml_file}')
+            print(f'  "{yaml_file}"')
             wireviz.parse_file(yaml_file)
 
             if build_readme:
@@ -91,16 +92,16 @@ def clean_generated(groupkeys):
         # collect and remove files
         for filename in collect_filenames('Cleaning', key, generated_extensions):
             if filename.is_file():
-                print(f'  rm {filename}')
+                print(f'  rm "{filename}"')
                 os.remove(filename)
 
 
-def compare_generated(groupkeys, include_from_graphviz = False):
-    compare_extensions = generated_extensions if include_from_graphviz else extensions_not_from_graphviz
+def compare_generated(groupkeys, include_graphviz_output = False):
+    compare_extensions = generated_extensions if include_graphviz_output else extensions_not_containing_graphviz_output
     for key in groupkeys:
         # collect and compare files
         for filename in collect_filenames('Comparing', key, compare_extensions):
-            cmd = f'git --no-pager diff {filename}'
+            cmd = f'git --no-pager diff "{filename}"'
             print(f'  {cmd}')
             os.system(cmd)
 
@@ -115,7 +116,7 @@ def restore_generated(groupkeys):
             filename_list.append(groups[key]['path'] / readme)
         # restore files
         for filename in filename_list:
-            cmd = f'git checkout -- {filename}'
+            cmd = f'git checkout -- "{filename}"'
             print(f'  {cmd}')
             os.system(cmd)
 

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -119,6 +119,8 @@ def open_file_read(filename):
 def open_file_write(filename):
     return open(filename, 'w', encoding='UTF-8')
 
+def open_file_append(filename):
+    return open(filename, 'a', encoding='UTF-8')
 
 def manufacturer_info_field(manufacturer, mpn):
     if manufacturer or mpn:


### PR DESCRIPTION
This PR ~~builds on top of #110 and~~ add some new features:
- Add `compare` action to compare generated files (except those generated by Graphviz unless using `-c`) against git repository.
- Add `restore` action to restore generated files from git repository.
- Make all actions honor the optional argument `-g`. This make it possible to select the group of files to use for any action by following the action argument with `-g` and then the space separated group names.

Edit: It should not break the existing `build` and `clean` actions, but their algorithms to collect files are slightly adjusted so they can use a common function to reduce code duplication.

These new features are useful for #63, but does not close it (collecting corner cases are also needed).

Edit 2: A few extra changes seen by the user:
- The CLI option `-generate` is renamed to `-g`/`--groups` and some argument help is added.
- The group name is included in the status output as the path is equal for two groups, and now it contains `{description} {groupkey} in {path}` e.g. `Building demos in /path/WireViz/examples`.

Usage:
- Run `python build_examples.py` to build generated files in all groups.
- Run `python build_examples.py compare` to compare generated files in all groups against the last commit.
- Run `python build_examples.py clean` to delete generated files in all groups.
- Run `python build_examples.py restore` to restore generated files in all groups from the last commit.
- Edit 4: Append `-c` or `--compare-graphviz-output` to the `compare` command above to also compare the Graphviz output (default: False).
- Append `-g` or `--groups` followed by space separated group names to any command above, and the set of generated files affected by the command will be limited to the selected groups.
- Run `python build_examples.py -h` or with `--help` to print the generated help. The auto-generated help text is not the best, but better than maintaining it manually. I wonder if [click](https://click.palletsprojects.com/en/7.x/) as recommended in https://github.com/formatc1702/WireViz/issues/60#issuecomment-663278159 could improve this?

Edit 3: This PR was originally built on top of #110, but is now rebased onto `dev` to prepare merge-in. The single commit from #110 that my commits depend on, is therefore now included here. Some of my commits are squashed together. The original branch before squash-rebasing is available as [kvid:extended-build-examples-before-rebase](https://github.com/kvid/WireViz/tree/extended-build-examples-before-rebase).

Personally, I want to use `python build_examples.py` followed by `python build_examples.py compare` as a regression test to easily see what has changed in the output files just re-generated compared to the latest commit. In addition, I want to use  `python build_examples.py restore` just before committing to avoid unwanted changes from e.g. a different Graphviz version. Hopefully, others also find this useful.