### PR TITLE
Make each shield wire uniform and allow cable.shield color

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -230,7 +230,14 @@ class Harness:
                 for bla in p:
                     html = html + f'<td>{bla}</td>'
                 html = f'{html}</tr>'
-                html = f'{html}<tr><td colspan="{len(p)}" cellpadding="0" height="6" border="2" sides="b" port="ws"></td></tr>'
+                if isinstance(cable.shield, str):
+                    # shield is shown with specified color and black borders
+                    shield_color_hex = wv_colors.get_color_hex(cable.shield)[0]
+                    attributes = f'height="6" bgcolor="{shield_color_hex}" border="2" sides="tb"'
+                else:
+                    # shield is shown as a thin black wire
+                    attributes = f'height="2" bgcolor="#000000" border="0"'
+                html = f'{html}<tr><td colspan="{len(p)}" cellpadding="0" {attributes} port="ws"></td></tr>'
 
             html = f'{html}<tr><td>&nbsp;</td></tr>'  # spacer at the end
 
@@ -248,8 +255,8 @@ class Harness:
                 if isinstance(connection_color.via_port, int):  # check if it's an actual wire and not a shield
                     dot.attr('edge', color=':'.join(['#000000'] + wv_colors.get_color_hex(cable.colors[connection_color.via_port - 1], pad=pad) + ['#000000']))
                 else:  # it's a shield connection
-                    # shield is shown as a thin tinned wire
-                    dot.attr('edge', color=':'.join(['#000000', wv_colors.get_color_hex('SN', pad=False)[0], '#000000']))
+                    # shield is shown with specified color and black borders, or as a thin black wire otherwise
+                    dot.attr('edge', color=':'.join(['#000000', shield_color_hex, '#000000']) if isinstance(cable.shield, str) else '#000000')
                 if connection_color.from_port is not None:  # connect to left
                     from_port = f':p{connection_color.from_port}r' if self.connectors[connection_color.from_name].style != 'simple' else ''
                     code_left_1 = f'{connection_color.from_name}{from_port}:e'


### PR DESCRIPTION
As the spline shield wires are rendered as thin tinned wires with black borders, and the shield wires in cable nodes were rendered as a single (bottom) border, they didn't fit well together, e.g. in [tutorial03.png](https://github.com/formatc1702/WireViz/blob/dev/tutorial/tutorial03.png):
![tutorial03](https://user-images.githubusercontent.com/12657033/88470965-27ee4680-cf03-11ea-8b94-0c52551411eb.png)

The shield wires in cable nodes are now rendered equally as the spline shield wires. The default behavior is now kept as before multi-colors were introduced. This is tutorial03.png produced after the fix:
![tutorial03](https://user-images.githubusercontent.com/12657033/88492246-971e7600-cfa9-11ea-9c40-0c20e30de5be.png)

The new feature is that `cable.shield` is allowed to contain a two-letter color code to specify a colored shield wire with black borders. This is tutorial03.png produced from a modified YAML file:
![tutorial03-fixed](https://user-images.githubusercontent.com/12657033/88470967-32a8db80-cf03-11ea-82d5-c9153b7a79f9.png)
```diff
--------------------------- tutorial/tutorial03.yml ---------------------------
index fba6e6d..fe75299 100644
@@ -13,7 +13,7 @@ cables:
     gauge: 0.25 mm2
     show_equiv: true
     color_code: DIN # auto-assign colors based on DIN 47100
-    shield: true # add cable shielding
+    shield: SN # add tinned cable shielding
 
 connections:
   -
```
With this new feature, it is also possible for the user to visualize copper or golden shields, and even different shields for different cables in the same diagram if needed.

The shield wire thickness is not increased, even if the cable has some multi-colored wires that makes all other wires to increase.

This fixes bug #125. I know #74 and/or #120 will probably change this, but as those draft PRs have no priority right now (in [milestone v0.3 = do later](https://github.com/formatc1702/WireViz/milestone/2)), I suggest this tiny little change as a quick solution for now.