### PR TITLE
default should be an iterable

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -211,7 +211,7 @@ class Harness:
 
         return dot
 
-    def output(self, filename, directory='_output', view=False, cleanup=True, fmt='pdf', gen_bom=False):
+    def output(self, filename, directory='_output', view=False, cleanup=True, fmt=('pdf',), gen_bom=False):
         # graphical output
         graph = self.create_graph()
         for f in fmt:


### PR DESCRIPTION
The code looks at `fmt` as an iterable. Tweak the default value to avoid iteration of 'p', 'd', 'f'.