### PR TITLE
Feature/gv html refactor

### DIFF
--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -149,8 +149,6 @@ class Cable:
                 else:
                     raise Exception('lists of part data are only supported for bundles')
 
-        # for BOM generation
-        self.wirecount_and_shield = (self.wirecount, self.shield)
 
     def connect(self, from_name, from_pin, via_pin, to_name, to_pin):
         from_pin = int2tuple(from_pin)

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -88,6 +88,7 @@ class Cable:
     gauge_unit: Optional[str] = None
     show_equiv: bool = False
     length: float = 0
+    color: Optional[str] = None
     wirecount: Optional[int] = None
     shield: bool = False
     notes: Optional[str] = None

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -112,16 +112,16 @@ class Harness:
                 for pin, pinlabel in zip(connector.pins, connector.pinlabels):
                     if connector.hide_disconnected_pins and not connector.visible_pins.get(pin, False):
                         continue
-                    pinhtml.append('<tr>')
+                    pinhtml.append('   <tr>')
                     if connector.ports_left:
-                        pinhtml.append(f'<td port="p{pin}l">{pin}</td>')
+                        pinhtml.append(f'    <td port="p{pin}l">{pin}</td>')
                     if pinlabel:
-                        pinhtml.append(f'<td>{pinlabel}</td>')
+                        pinhtml.append(f'    <td>{pinlabel}</td>')
                     if connector.ports_right:
-                        pinhtml.append(f'<td port="p{pin}r">{pin}</td>')
-                    pinhtml.append('</tr>')
+                        pinhtml.append(f'    <td port="p{pin}r">{pin}</td>')
+                    pinhtml.append('   </tr>')
 
-                pinhtml.append('</table>')
+                pinhtml.append('  </table>')
 
                 html = [row.replace('<!-- connector table -->', '\n'.join(pinhtml)) for row in html]
 
@@ -182,22 +182,24 @@ class Harness:
 
             wirehtml = []
             wirehtml.append('<table border="0" cellspacing="0" cellborder="0">')  # conductor table
-            wirehtml.append('<tr><td>&nbsp;</td></tr>')
+            wirehtml.append('   <tr><td>&nbsp;</td></tr>')
 
             for i, connection_color in enumerate(cable.colors, 1):
-                wirehtml.append('<tr>')
-                wirehtml.append(f'<td><!-- {i}_in --></td>')
-                wirehtml.append(f'<td>{wv_colors.translate_color(connection_color, self.color_mode)}</td>')
-                wirehtml.append(f'<td><!-- {i}_out --></td>')
-                wirehtml.append('</tr>')
+                wirehtml.append('   <tr>')
+                wirehtml.append(f'    <td><!-- {i}_in --></td>')
+                wirehtml.append(f'    <td>{wv_colors.translate_color(connection_color, self.color_mode)}</td>')
+                wirehtml.append(f'    <td><!-- {i}_out --></td>')
+                wirehtml.append('   </tr>')
 
                 bgcolors = ['#000000'] + get_color_hex(connection_color, pad=pad) + ['#000000']
-                wirehtml.append(f'<tr><td colspan="3" border="0" cellspacing="0" cellpadding="0" port="w{i}" height="{(2 * len(bgcolors))}">')
-                wirehtml.append('<table cellspacing="0" cellborder="0" border="0">')
+                wirehtml.append(f'   <tr>')
+                wirehtml.append(f'    <td colspan="3" border="0" cellspacing="0" cellpadding="0" port="w{i}" height="{(2 * len(bgcolors))}">')
+                wirehtml.append('     <table cellspacing="0" cellborder="0" border="0">')
                 for j, bgcolor in enumerate(bgcolors[::-1]):  # Reverse to match the curved wires when more than 2 colors
-                    wirehtml.append(f'<tr><td colspan="3" cellpadding="0" height="2" bgcolor="{bgcolor if bgcolor != "" else wv_colors.default_color}" border="0"></td></tr>')
-                wirehtml.append('</table>')
-                wirehtml.append('</td></tr>')
+                    wirehtml.append(f'      <tr><td colspan="3" cellpadding="0" height="2" bgcolor="{bgcolor if bgcolor != "" else wv_colors.default_color}" border="0"></td></tr>')
+                wirehtml.append('     </table>')
+                wirehtml.append('    </td>')
+                wirehtml.append('   </tr>')
                 if(cable.category == 'bundle'):  # for bundles individual wires can have part information
                     # create a list of wire parameters
                     wireidentification = []
@@ -210,20 +212,20 @@ class Harness:
                         wireidentification.append(html_line_breaks(manufacturer_info))
                     # print parameters into a table row under the wire
                     if(len(wireidentification) > 0):
-                        wirehtml.append('<tr><td colspan="3">')
-                        wirehtml.append('<table border="0" cellspacing="0" cellborder="0"><tr>')
+                        wirehtml.append('   <tr><td colspan="3">')
+                        wirehtml.append('    <table border="0" cellspacing="0" cellborder="0"><tr>')
                         for attrib in wireidentification:
-                            wirehtml.append(f'<td>{attrib}</td>')
-                        wirehtml.append('</tr></table>')
-                        wirehtml.append('</td></tr>')
+                            wirehtml.append(f'     <td>{attrib}</td>')
+                        wirehtml.append('    </tr></table>')
+                        wirehtml.append('   </td></tr>')
 
             if cable.shield:
-                wirehtml.append('<tr><td>&nbsp;</td></tr>')  # spacer
-                wirehtml.append('<tr>')
-                wirehtml.append('<td><!-- s_in --></td>')
-                wirehtml.append('<td>Shield</td>')
-                wirehtml.append('<td><!-- s_out --></td>')
-                wirehtml.append('</tr>')
+                wirehtml.append('   <tr><td>&nbsp;</td></tr>')  # spacer
+                wirehtml.append('   <tr>')
+                wirehtml.append('    <td><!-- s_in --></td>')
+                wirehtml.append('    <td>Shield</td>')
+                wirehtml.append('    <td><!-- s_out --></td>')
+                wirehtml.append('   </tr>')
                 if isinstance(cable.shield, str):
                     # shield is shown with specified color and black borders
                     shield_color_hex = wv_colors.get_color_hex(cable.shield)[0]
@@ -231,10 +233,10 @@ class Harness:
                 else:
                     # shield is shown as a thin black wire
                     attributes = f'height="2" bgcolor="#000000" border="0"'
-                wirehtml.append(f'<tr><td colspan="3" cellpadding="0" {attributes} port="ws"></td></tr>')
+                wirehtml.append(f'   <tr><td colspan="3" cellpadding="0" {attributes} port="ws"></td></tr>')
 
-            wirehtml.append('<tr><td>&nbsp;</td></tr>')
-            wirehtml.append('</table>')
+            wirehtml.append('   <tr><td>&nbsp;</td></tr>')
+            wirehtml.append('  </table>')
 
             html = [row.replace('<!-- wire table -->', '\n'.join(wirehtml)) for row in html]
 

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -197,8 +197,9 @@ class Harness:
                     wireidentification = []
                     if isinstance(cable.pn, list):
                         wireidentification.append(f'P/N: {cable.pn[i - 1]}')
-                    manufacturer_info = manufacturer_info_field(cable.manufacturer[i - 1] if isinstance(cable.manufacturer, list) else None,
-                                                                      cable.mpn[i - 1] if isinstance(cable.mpn, list) else None)
+                    manufacturer_info = manufacturer_info_field(
+                        cable.manufacturer[i - 1] if isinstance(cable.manufacturer, list) else None,
+                        cable.mpn[i - 1] if isinstance(cable.mpn, list) else None)
                     if manufacturer_info:
                         wireidentification.append(html_line_breaks(manufacturer_info))
                     # print parameters into a table row under the wire
@@ -335,7 +336,7 @@ class Harness:
             conn_color = f', {shared.color}' if shared.color else ''
             name = f'Connector{conn_type}{conn_subtype}{conn_pincount}{conn_color}'
             item = {'item': name, 'qty': len(designators), 'unit': '', 'designators': designators if shared.show_name else '',
-                    'manufacturer': shared.manufacturer, 'mpn': shared.mpn, 'pn': shared.pn}
+                    'manufacturer': remove_line_breaks(shared.manufacturer), 'mpn': remove_line_breaks(shared.mpn), 'pn': shared.pn}
             bom_connectors.append(item)
             bom_connectors = sorted(bom_connectors, key=lambda k: k['item'])  # https://stackoverflow.com/a/73050
         bom.extend(bom_connectors)
@@ -354,7 +355,7 @@ class Harness:
             shield_name = ' shielded' if shared.shield else ''
             name = f'Cable{cable_type}, {shared.wirecount}{gauge_name}{shield_name}'
             item = {'item': name, 'qty': round(total_length, 3), 'unit': 'm', 'designators': designators,
-                    'manufacturer': shared.manufacturer, 'mpn': shared.mpn, 'pn': shared.pn}
+                    'manufacturer': remove_line_breaks(shared.manufacturer), 'mpn': remove_line_breaks(shared.mpn), 'pn': shared.pn}
             bom_cables.append(item)
         # bundles (ignores wirecount)
         wirelist = []
@@ -364,8 +365,8 @@ class Harness:
                 # add each wire from each bundle to the wirelist
                 for index, color in enumerate(bundle.colors, 0):
                     wirelist.append({'type': bundle.type, 'gauge': bundle.gauge, 'gauge_unit': bundle.gauge_unit, 'length': bundle.length, 'color': color, 'designator': bundle.name,
-                                     'manufacturer': index_if_list(bundle.manufacturer, index),
-                                     'mpn': index_if_list(bundle.mpn, index),
+                                     'manufacturer': remove_line_breaks(index_if_list(bundle.manufacturer, index)),
+                                     'mpn': remove_line_breaks(index_if_list(bundle.mpn, index)),
                                      'pn': index_if_list(bundle.pn, index)})
         # join similar wires from all the bundles to a single BOM item
         wire_group = lambda w: (w.get('type', None), w['gauge'], w['gauge_unit'], w['color'], w['manufacturer'], w['mpn'], w['pn'])

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -163,11 +163,16 @@ class Harness:
                      f'{len(cable.colors)}x' if cable.show_wirecount else None,
                      f'{cable.gauge} {cable.gauge_unit}{awg_fmt}' if cable.gauge else None,
                      '+ S' if cable.shield else None,
-                     f'{cable.length} m' if cable.length > 0 else None],
+                     f'{cable.length} m' if cable.length > 0 else None,
+                     cable.color, '<!-- colorbar -->' if cable.color else None],
                     '<!-- wire table -->',
                     [html_line_breaks(cable.notes)]]
             html = nested_html_table(rows)
 
+            if cable.color: # add color bar next to color info, if present
+                colorbar = f' bgcolor="{wv_colors.translate_color(cable.color, "HEX")}" width="4"></td>' # leave out '<td' from string to preserve any existing attributes of the <td> tag
+                html = html.replace('><!-- colorbar --></td>', colorbar)
+            
             wirehtml = '<table border="0" cellspacing="0" cellborder="0">'  # conductor table
             wirehtml = f'{wirehtml}<tr><td>&nbsp;</td></tr>'
 

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -34,18 +34,23 @@ def nested_html_table(rows):
     # input: list, each item may be scalar or list
     # output: a parent table with one child table per parent item that is list, and one cell per parent item that is scalar
     # purpose: create the appearance of one table, where cell widths are independent between rows
-    html = '<table border="0" cellspacing="0" cellpadding="0">'
+    html = []
+    html.append('<table border="0" cellspacing="0" cellpadding="0">')
     for row in rows:
         if isinstance(row, List):
             if len(row) > 0 and any(row):
-                html = f'{html}<tr><td><table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr>'
+                html.append('<tr><td>')
+                html.append('<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr>')
                 for cell in row:
                     if cell is not None:
-                        html = f'{html}<td balign="left">{cell}</td>'
-                html = f'{html}</tr></table></td></tr>'
+                        html.append(f'<td balign="left">{cell}</td>')
+                html.append('</tr></table>')
+                html.append('</td></tr>')
         elif row is not None:
-            html = f'{html}<tr><td>{row}</td></tr>'
-    html = f'{html}</table>'
+            html.append('<tr><td>')
+            html.append(row)
+            html.append('</td></tr>')
+    html.append('</table>')
     return html
 
 

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -39,17 +39,17 @@ def nested_html_table(rows):
     for row in rows:
         if isinstance(row, List):
             if len(row) > 0 and any(row):
-                html.append('<tr><td>')
-                html.append('<table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr>')
+                html.append(' <tr><td>')
+                html.append('  <table border="0" cellspacing="0" cellpadding="3" cellborder="1"><tr>')
                 for cell in row:
                     if cell is not None:
-                        html.append(f'<td balign="left">{cell}</td>')
-                html.append('</tr></table>')
-                html.append('</td></tr>')
+                        html.append(f'   <td balign="left">{cell}</td>')
+                html.append('  </tr></table>')
+                html.append(' </td></tr>')
         elif row is not None:
-            html.append('<tr><td>')
-            html.append(row)
-            html.append('</td></tr>')
+            html.append(' <tr><td>')
+            html.append(f'  {row}')
+            html.append(' </td></tr>')
     html.append('</table>')
     return html
 

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -115,7 +115,7 @@ def graphviz_line_breaks(inp):
     return inp.replace('\n', '\\n') if isinstance(inp, str) else inp # \n generates centered new lines. http://www.graphviz.org/doc/info/attrs.html#k:escString
 
 def remove_line_breaks(inp):
-    return inp.replace('\n', ' ').rstrip() if isinstance(inp, str) else inp
+    return inp.replace('\n', ' ').strip() if isinstance(inp, str) else inp
 
 def open_file_read(filename):
     # TODO: Intelligently determine encoding


### PR DESCRIPTION
Fixes #66.

Adds a `color` property to cables, to match the behavior of connectors, for consistency.

This might be useful, for example, for highlighting cables that remain live after an emergency stop or mains disconnection, that need to be orange-coloured according to certain standards ([Source](https://www.elektropraktiker.de/nc/fachartikel/leiterkennzeichung-in-der-farbe-orange/) in German).