### PR TITLE
Add option to add colors to connector pins

### DIFF
--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -125,7 +125,7 @@ class Connector:
                 raise Exception('You need to specify at least one, pincount, pins or pinlabels')
             self.pincount = max(len(self.pins), len(self.pinlabels), len(self.pincolors))
 
-        # create default lists for pins (sequential) and pinlabels (blank) if not specified
+        # create default list for pins (sequential) if not specified
         if not self.pins:
             self.pins = list(range(1, self.pincount + 1))
 

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -96,6 +96,7 @@ class Connector:
     notes: Optional[MultilineHypertext] = None
     pinlabels: List[Pin] = field(default_factory=list)
     pins: List[Pin] = field(default_factory=list)
+    pincolors: List[Color] = field(default_factory=list)
     color: Optional[Color] = None
     show_name: Optional[bool] = None
     show_pincount: Optional[bool] = None
@@ -139,6 +140,9 @@ class Connector:
 
         if len(self.pins) != len(set(self.pins)):
             raise Exception('Pins are not unique')
+
+        if self.pincolors:
+            self.pincolors.extend([None] * (len(self.pins) - len(self.pincolors)))  # autofill missing pincolors as 'no color'
 
         if self.show_name is None:
             self.show_name = not self.autogenerate # hide auto-generated designators by default

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -120,29 +120,17 @@ class Connector:
                 raise Exception('Connectors with style set to simple may only have one pin')
             self.pincount = 1
 
-        if self.pincount is None:
-            if self.pinlabels:
-                self.pincount = len(self.pinlabels)
-            elif self.pins:
-                self.pincount = len(self.pins)
-            else:
+        if not self.pincount:
+            if not self.pins and not self.pinlabels:
                 raise Exception('You need to specify at least one, pincount, pins or pinlabels')
-
-        if self.pinlabels and self.pins:
-            if len(self.pinlabels) != len(self.pins):
-                raise Exception('Given pins and pinlabels size mismatch')
+            self.pincount = max(len(self.pins), len(self.pinlabels), len(self.pincolors))
 
         # create default lists for pins (sequential) and pinlabels (blank) if not specified
         if not self.pins:
             self.pins = list(range(1, self.pincount + 1))
-        if not self.pinlabels:
-            self.pinlabels = [''] * self.pincount
 
         if len(self.pins) != len(set(self.pins)):
             raise Exception('Pins are not unique')
-
-        if self.pincolors:
-            self.pincolors.extend([None] * (len(self.pins) - len(self.pincolors)))  # autofill missing pincolors as 'no color'
 
         if self.show_name is None:
             self.show_name = not self.autogenerate # hide auto-generated designators by default

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -121,9 +121,9 @@ class Connector:
             self.pincount = 1
 
         if not self.pincount:
-            if not self.pins and not self.pinlabels:
-                raise Exception('You need to specify at least one, pincount, pins or pinlabels')
             self.pincount = max(len(self.pins), len(self.pinlabels), len(self.pincolors))
+            if not self.pincount:
+                raise Exception('You need to specify at least one, pincount, pins, pinlabels, or pincolors')
 
         # create default list for pins (sequential) if not specified
         if not self.pins:

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -12,6 +12,7 @@ from wireviz.wv_helper import awg_equiv, mm2_equiv, tuplelist2tsv, \
 from collections import Counter
 from typing import List, Union
 from pathlib import Path
+from itertools import zip_longest
 import re
 
 
@@ -110,9 +111,7 @@ class Harness:
                 pinhtml = []
                 pinhtml.append('<table border="0" cellspacing="0" cellpadding="3" cellborder="1">')
 
-                for pin, pinlabel, pincolor in zip(connector.pins,
-                                                   connector.pinlabels,
-                                                   connector.pincolors if connector.pincolors else [None] * len(connector.pins)):
+                for pin, pinlabel, pincolor in zip_longest(connector.pins, connector.pinlabels, connector.pincolors):
                     if connector.hide_disconnected_pins and not connector.visible_pins.get(pin, False):
                         continue
                     pinhtml.append('   <tr>')
@@ -122,11 +121,10 @@ class Harness:
                         pinhtml.append(f'    <td>{pinlabel}</td>')
                     if connector.pincolors:
                         if pincolor in wv_colors._color_hex.keys():
-                            pinhtml.append(f'<td sides="tbl">{pincolor}</td>')
-                            pinhtml.append(f'<td sides="tbr"><table border="0" cellborder="1"><tr><td bgcolor="{wv_colors.translate_color(pincolor, "HEX")}" width="8" height="8" fixedsize="true"></td></tr></table></td>')
+                            pinhtml.append(f'    <td sides="tbl">{pincolor}</td>')
+                            pinhtml.append(f'    <td sides="tbr"><table border="0" cellborder="1"><tr><td bgcolor="{wv_colors.translate_color(pincolor, "HEX")}" width="8" height="8" fixedsize="true"></td></tr></table></td>')
                         else:
-                            pinhtml.append(f'<td sides="tbl"></td>')
-                            pinhtml.append(f'<td sides="tbr"></td>')
+                            pinhtml.append(f'    <td colspan="2"></td>')
 
                     if connector.ports_right:
                         pinhtml.append(f'    <td port="p{pin}r">{pin}</td>')

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -110,7 +110,9 @@ class Harness:
                 pinhtml = []
                 pinhtml.append('<table border="0" cellspacing="0" cellpadding="3" cellborder="1">')
 
-                for pin, pinlabel in zip(connector.pins, connector.pinlabels):
+                for pin, pinlabel, pincolor in zip(connector.pins,
+                                                   connector.pinlabels,
+                                                   connector.pincolors if connector.pincolors else [None] * len(connector.pins)):
                     if connector.hide_disconnected_pins and not connector.visible_pins.get(pin, False):
                         continue
                     pinhtml.append('   <tr>')
@@ -118,6 +120,14 @@ class Harness:
                         pinhtml.append(f'    <td port="p{pin}l">{pin}</td>')
                     if pinlabel:
                         pinhtml.append(f'    <td>{pinlabel}</td>')
+                    if connector.pincolors:
+                        if pincolor in wv_colors._color_hex.keys():
+                            pinhtml.append(f'<td sides="tbl">{pincolor}</td>')
+                            pinhtml.append(f'<td sides="tbr"><table border="0" cellborder="1"><tr><td bgcolor="{wv_colors.translate_color(pincolor, "HEX")}" width="8" height="8" fixedsize="true"></td></tr></table></td>')
+                        else:
+                            pinhtml.append(f'<td sides="tbl"></td>')
+                            pinhtml.append(f'<td sides="tbr"></td>')
+
                     if connector.ports_right:
                         pinhtml.append(f'    <td port="p{pin}r">{pin}</td>')
                     pinhtml.append('   </tr>')

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -122,9 +122,13 @@ class Harness:
                     if connector.pincolors:
                         if pincolor in wv_colors._color_hex.keys():
                             pinhtml.append(f'    <td sides="tbl">{pincolor}</td>')
-                            pinhtml.append(f'    <td sides="tbr"><table border="0" cellborder="1"><tr><td bgcolor="{wv_colors.translate_color(pincolor, "HEX")}" width="8" height="8" fixedsize="true"></td></tr></table></td>')
+                            pinhtml.append( '    <td sides="tbr">')
+                            pinhtml.append( '     <table border="0" cellborder="1"><tr>')
+                            pinhtml.append(f'      <td bgcolor="{wv_colors.translate_color(pincolor, "HEX")}" width="8" height="8" fixedsize="true"></td>')
+                            pinhtml.append( '     </tr></table>')
+                            pinhtml.append( '    </td>')
                         else:
-                            pinhtml.append(f'    <td colspan="2"></td>')
+                            pinhtml.append( '    <td colspan="2"></td>')
 
                     if connector.ports_right:
                         pinhtml.append(f'    <td port="p{pin}r">{pin}</td>')


### PR DESCRIPTION
Closes #53.
Based on `feature/gv-html-refactor` branch.

- Adds new `pincolors` list attribute to connectors.
  - If `pincolors` is used, needs to be the same length as `pins`, `pinlabels`
- If used, displays a small color mark and label next to each pin
  - Color mark is smaller than the `connector.color` mark on purpose
- Implements `__` as placeholder for pins with no color
  - Better suggestions welcome
  - Edit 2020-10-21: Any unknown color code is treated as "no color", so `__`, `--`, `XX` and anything else may be used.
- Makes sure white color marks look decent on white background
  - TODO in the future: detect what background color is used, and react accordingly

Example:
```yaml
connectors:
  X1:
    type: D-Sub
    subtype: female
    color: GY
    pins:      [5,   2,  3,  99,  98,  97,  96,  95,  94]
    pinlabels: [DCD, RX, TX, DTR, GND, DSR, RTS, CTS, RI]
    pincolors: [PK,  RD,  OG, YE, GN,  TQ,  LB,  BU,  VT]
  X2:
    type: Molex KK 254
    subtype: female
    color: BG
    pinlabels: [GND, RX, TX, N/C, N/C, N/C]
    pincolors: [GD,  SR, CU, __ , BK,  WH ]

cables:
  W1:
    gauge: 0.25 mm2
    length: 0.2
    color_code: DIN
    wirecount: 3
    shield: true

connections:
  -
    - X1: [5,2,3]
    - W1: [1,2,3]
    - X2: [1,3,2]
  -
    - X1: 5
    - W1: s
```

![test](https://user-images.githubusercontent.com/2447251/88955048-a9dfc600-d29b-11ea-9d97-e2db3aa80927.png)
