### PR TITLE
extend unknown color error message

### DIFF
--- a/src/wireviz/wv_colors.py
+++ b/src/wireviz/wv_colors.py
@@ -112,7 +112,7 @@ def get_color_hex(input, pad=False):
     try:
         output = [_color_hex[input[i:i + 2]] for i in range(0, len(input), 2)]
     except KeyError:
-        print("Unknown color specified")
+        print(f"Unknown color specified: {input}")
         output = [color_default]
     return output
 

--- a/src/wireviz/wv_colors.py
+++ b/src/wireviz/wv_colors.py
@@ -104,15 +104,18 @@ color_default = '#ffffff'
 def get_color_hex(input, pad=False):
     if input is None or input == '':
         return [color_default]
+
     if len(input) == 4:  # give wires with EXACTLY 2 colors that striped/banded look
-        input = input + input[:2]
-    # hacky style fix: give single color wires a triple-up so that wires are the same size
-    if pad and len(input) == 2:
-        input = input + input + input
+        padded = input + input[:2]
+    elif pad and len(input) == 2: # hacky style fix: give single color wires a triple-up so that wires are the same size
+        padded = input + input + input
+    else:
+        padded = input
+
     try:
-        output = [_color_hex[input[i:i + 2]] for i in range(0, len(input), 2)]
+        output = [_color_hex[padded[i:i + 2]] for i in range(0, len(input), 2)]
     except KeyError:
-        print(f"Unknown color specified: {input}")
+        print(f'Unknown color specified: {input}')
         output = [color_default]
     return output
 


### PR DESCRIPTION
print out the color string that cannot be found so the user has it easier to fix typos.