### PR TITLE
Add .gitattributes for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+docs/* linguist-documentation
+
+examples/* -linguist-detectable
+tutorial/* -linguist-detectable
+
+**/*.bom.tsv linguist-generated
+**/*.bom.csv linguist-generated
+**/*.gv linguist-generated
+**/*.html linguist-generated
+**/*.png linguist-generated
+**/*.svg linguist-generated


### PR DESCRIPTION
This is an attempt to
- avoid the `examples/` and `tutorial/` directories to be included in the project's language statistics
- mark any WireViz output files (TSV, CSV, GV, HTML, SVG, PNG) as generated files

Unfortunately, it seems that the statistics are only updated when merged into `master`, so maybe someone with more experience can confirm that my implemenation will actually have the intended effect.