### PR TITLE
Remove HTML links from the input attributes 

### DIFF
--- a/examples/ex05.yml
+++ b/examples/ex05.yml
@@ -1,7 +1,7 @@
 # daisy chain, variant 1
 templates:
   - &template_con
-    type: Molex KK 254
+    type: '<a href="https://www.molex.com/molex/products/family/kk_254_rpc_connector_system">Molex KK 254</a>'
     subtype: female
     pinlabels: [GND, VCC, SCL, SDA]
   - &template_wire

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -8,7 +8,7 @@ from wireviz.wv_colors import get_color_hex
 from wireviz.wv_helper import awg_equiv, mm2_equiv, tuplelist2tsv, \
     nested_html_table, flatten2d, index_if_list, html_line_breaks, \
     clean_whitespace, open_file_read, open_file_write, html_colorbar, \
-    html_image, html_caption, manufacturer_info_field, component_table_entry
+    html_image, html_caption, manufacturer_info_field, component_table_entry, remove_links
 from collections import Counter
 from typing import List, Union
 from pathlib import Path
@@ -92,8 +92,8 @@ class Harness:
 
             html = []
 
-            rows = [[connector.name if connector.show_name else None],
-                    [f'P/N: {connector.pn}' if connector.pn else None,
+            rows = [[remove_links(connector.name) if connector.show_name else None],
+                    [f'P/N: {remove_links(connector.pn)}' if connector.pn else None,
                      html_line_breaks(manufacturer_info_field(connector.manufacturer, connector.mpn))],
                     [html_line_breaks(connector.type),
                      html_line_breaks(connector.subtype),
@@ -162,8 +162,8 @@ class Harness:
                 elif cable.gauge_unit.upper() == 'AWG':
                     awg_fmt = f' ({mm2_equiv(cable.gauge)} mm\u00B2)'
 
-            rows = [[cable.name if cable.show_name else None],
-                    [f'P/N: {cable.pn}' if (cable.pn and not isinstance(cable.pn, list)) else None,
+            rows = [[remove_links(cable.name) if cable.show_name else None],
+                    [f'P/N: {remove_links(cable.pn)}' if (cable.pn and not isinstance(cable.pn, list)) else None,
                      html_line_breaks(manufacturer_info_field(
                         cable.manufacturer if not isinstance(cable.manufacturer, list) else None,
                         cable.mpn if not isinstance(cable.mpn, list) else None))],
@@ -205,7 +205,7 @@ class Harness:
                     # create a list of wire parameters
                     wireidentification = []
                     if isinstance(cable.pn, list):
-                        wireidentification.append(f'P/N: {cable.pn[i - 1]}')
+                        wireidentification.append(f'P/N: {remove_links(cable.pn[i - 1])}')
                     manufacturer_info = manufacturer_info_field(
                         cable.manufacturer[i - 1] if isinstance(cable.manufacturer, list) else None,
                         cable.mpn[i - 1] if isinstance(cable.mpn, list) else None)

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -3,6 +3,7 @@
 
 from wireviz import wv_colors
 from typing import List
+import re
 
 awg_equiv_table = {
     '0.09': '28',
@@ -136,15 +137,18 @@ def tuplelist2tsv(inp, header=None):
         inp.insert(0, header)
     inp = flatten2d(inp)
     for row in inp:
-        output = output + '\t'.join(str(item) for item in row) + '\n'
+        output = output + '\t'.join(str(remove_links(item)) for item in row) + '\n'
     return output
 
 # Return the value indexed if it is a list, or simply the value otherwise.
 def index_if_list(value, index):
     return value[index] if isinstance(value, list) else value
 
+def remove_links(inp):
+    return re.sub(r'<[aA] [^>]*>([^<]*)</[aA]>', r'\1', inp) if isinstance(inp, str) else inp
+
 def html_line_breaks(inp):
-    return inp.replace('\n', '<br />') if isinstance(inp, str) else inp
+    return remove_links(inp).replace('\n', '<br />') if isinstance(inp, str) else inp
 
 def clean_whitespace(inp):
     return ' '.join(inp.split()).replace(' ,', ',') if isinstance(inp, str) else inp

--- a/tutorial/tutorial08.yml
+++ b/tutorial/tutorial08.yml
@@ -3,8 +3,8 @@ connectors:
     type: Molex KK 254
     pincount: 4
     subtype: female
-    manufacturer: Molex # set manufacter name
-    mpn: 22013047 # set manufacturer part number
+    manufacturer: '<a href="https://www.molex.com/">Molex</a>' # set manufacter name
+    mpn: '<a href="https://www.molex.com/molex/products/part-detail/crimp_housings/0022013047">22013047</a>' # set manufacturer part number
     # add a list of additional components to a part (shown in graph)
     additional_components:
       -
@@ -63,6 +63,6 @@ additional_bom_items:
     designators:
       - X2
       - X3
-    manufacturer: generic company
-    mpn: Label1
+    manufacturer: '<a href="https://www.bradyid.com">Brady</a>'
+    mpn: '<a href="https://www.bradyid.com/wire-cable-labels/bmp71-bmp61-m611-tls-2200-nylon-cloth-wire-general-id-labels-cps-2958789">B-499</a>'
     pn: Label-ID-1


### PR DESCRIPTION
This change will remove HTML links from the input attributes when generating graphs with GraphViz (because it does not support this HTML tag).

This way these links could be used generated the HTML BoM table (basically without changing the input) where they could be useful.

```
# Example 7: Crossover Cable
connectors:
  X1:
    type: '<a href="https://www.digikey.com/product-detail/en/stewart-connector/SS-37000-002/380-1098-ND/1033365">Stewart Connector SS-37000-002</a>'
    subtype: male
    pinlabels: [DA+,DA-,DB+,DC+,DC-,DB-,DD+,DD-] # pincount is implicit in pinout
  X2:
    type: '<a href="https://www.digikey.com/product-detail/en/stewart-connector/SS-37000-002/380-1098-ND/1033365">Stewart Connector SS-37000-002</a>'
    subtype: male
    pinlabels: [DB+,DB-,DA+,DD+,DD-,DA-,DC+,DC-]

```
Results:
![kép](https://user-images.githubusercontent.com/1609182/92620648-27e3b380-f2c3-11ea-88aa-0056ff333112.png)

BTW.  it might be useful to add some links to some examples just to make some attention on this feature.