### PR TITLE
Add optional tweaking of the .gv output

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -345,10 +345,11 @@ Alternatively items can be added to just the BOM by putting them in the section 
     # Entries with an attribute containing HTML are
     # not supported.
     <str>:  # leading string of .gv entry
-      <str> : <str>  # attribute and its new value
+      <str> : <str/null>  # attribute and its new value
       # Any number of attributes can be overridden
       # for each entry. Attributes not already existing
       # in the entry will be appended to the entry.
+      # Use null as new value to delete an attribute.
 
   append: <str/list> # string or list of strings to append to the .gv output
 ```

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -35,6 +35,8 @@ additional_bom_items:  # custom items to add to BOM
   - <bom-item>           # BOM item (see below)
   ...
 
+tweak:  # optional tweaking of .gv output
+  ...
 ```
 
 ## Metadata entries
@@ -327,6 +329,30 @@ Alternatively items can be added to just the BOM by putting them in the section 
   manufacturer: <str>  # manufacturer name  
 ```
 
+## Tweak entries
+
+```yaml
+  # Optional tweaking of the .gv output.
+  # This feature is experimental and might change
+  # or be removed in future versions.
+
+  override:  # dict of .gv entries to override
+    # Each entry is identified by its leading string
+    # in lines beginning with a TAB character.
+    # The leading string might be in "quotes" in 
+    # the .gv output. This leading string must be
+    # followed by attributes in [square brackets].
+    # Entries containing HTML in an attribute are
+    # not supported.
+    <str>:  # leading string of .gv entry
+      <str> : <str>  # attribute and its new value
+      # Any number of attributes can be overridden
+      # for each entry
+
+  append:  # single or list of .gv entries to append
+    <str>  # strings to append might have multiple lines
+```
+
 ## Colors
 
 Colors are defined via uppercase, two character strings.
@@ -403,6 +429,7 @@ The following attributes accept multiline strings:
 - `manufacturer`
 - `mpn`
 - `image.caption`
+- `tweak.append`
 
 ### Method 1
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -347,7 +347,8 @@ Alternatively items can be added to just the BOM by putting them in the section 
     <str>:  # leading string of .gv entry
       <str> : <str>  # attribute and its new value
       # Any number of attributes can be overridden
-      # for each entry
+      # for each entry. Attributes not already existing
+      # in the entry will be appended to the entry.
 
   append: <str/list> # string or list of strings to append to the .gv output
 ```

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -329,7 +329,7 @@ Alternatively items can be added to just the BOM by putting them in the section 
   manufacturer: <str>  # manufacturer name  
 ```
 
-## Tweak entries
+## GraphViz tweaking (experimental)
 
 ```yaml
   # Optional tweaking of the .gv output.
@@ -342,15 +342,14 @@ Alternatively items can be added to just the BOM by putting them in the section 
     # The leading string might be in "quotes" in 
     # the .gv output. This leading string must be
     # followed by attributes in [square brackets].
-    # Entries containing HTML in an attribute are
+    # Entries with an attribute containing HTML are
     # not supported.
     <str>:  # leading string of .gv entry
       <str> : <str>  # attribute and its new value
       # Any number of attributes can be overridden
       # for each entry
 
-  append:  # single or list of .gv entries to append
-    <str>  # strings to append might have multiple lines
+  append: <str/list> # string or list of strings to append to the .gv output
 ```
 
 ## Colors

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -60,6 +60,12 @@ class Options:
 
 
 @dataclass
+class Tweak:
+    override: Optional[Dict[Designator, Dict[str, str]]] = None
+    append: Union[str, List[str], None] = None
+
+
+@dataclass
 class Image:
     gv_dir: InitVar[Path] # Directory of .gv file injected as context during parsing
     # Attributes of the image object <img>:

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -61,7 +61,7 @@ class Options:
 
 @dataclass
 class Tweak:
-    override: Optional[Dict[Designator, Dict[str, str]]] = None
+    override: Optional[Dict[Designator, Dict[str, Optional[str]]]] = None
     append: Union[str, List[str], None] = None
 
 

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -3,7 +3,7 @@
 
 from graphviz import Graph
 from collections import Counter
-from typing import List, Union
+from typing import Any, List, Union
 from dataclasses import dataclass
 from pathlib import Path
 from itertools import zip_longest
@@ -345,9 +345,9 @@ class Harness:
             dot.node(cable.name, label=f'<\n{html}\n>', shape='box',
                      style=style, fillcolor=translate_color(bgcolor, "HEX"))
 
-        def typecheck(name: str, var, type) -> None:
-            if not isinstance(var, type):
-                raise Exception(f'Unexpected value type of {name}: {var}')
+        def typecheck(name: str, value: Any, expect: type) -> None:
+            if not isinstance(value, expect):
+                raise Exception(f'Unexpected value type of {name}: Expected {expect}, got {type(value)}\n{value}')
 
         # TODO?: Differ between override attributes and HTML?
         if self.tweak.override is not None:
@@ -380,7 +380,7 @@ class Harness:
                     typecheck(f'tweak.append[{i}]', element, str)
                 dot.body.extend(self.tweak.append)
             else:
-                typecheck(f'tweak.append', self.tweak.append, str)
+                typecheck('tweak.append', self.tweak.append, str)
                 dot.body.append(self.tweak.append)
 
         return dot

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -367,11 +367,16 @@ class Harness:
                     keyword = match and match[2]
                     if keyword in self.tweak.override.keys():
                         for attr, value in self.tweak.override[keyword].items():
+                            # TODO?: If value is None: delete attr?
                             if len(value) == 0 or ' ' in value:
                                 value = value.replace('"', r'\"')
                                 value = f'"{value}"'
-                            # TODO?: If value is None: delete attr, and if attr not found: append it?
-                            entry = re.sub(f'{attr}=("[^"]*"|[^] ]*)', f'{attr}={value}', entry)
+                            entry, n_subs = re.subn(f'{attr}=("[^"]*"|[^] ]*)', f'{attr}={value}', entry)
+                            if n_subs < 1:
+                                # If attr not found, then append it
+                                entry = re.sub(r'\]$', f' {attr}={value}]', entry)
+                            elif n_subs > 1:
+                                print(f'Harness.create_graph() warning: {attr} overridden {n_subs} times in {keyword}!')
                         dot.body[i] = entry
 
         if self.tweak.append is not None:

--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from wireviz import __version__
-from wireviz.DataClasses import Metadata, Options
+from wireviz.DataClasses import Metadata, Options, Tweak
 from wireviz.Harness import Harness
 from wireviz.wv_helper import expand, open_file_read
 
@@ -38,6 +38,7 @@ def parse(yaml_input: str, file_out: (str, Path) = None, return_types: (None, st
     harness = Harness(
         metadata = Metadata(**yaml_data.get('metadata', {})),
         options = Options(**yaml_data.get('options', {})),
+        tweak = Tweak(**yaml_data.get('tweak', {})),
     )
     if 'title' not in harness.metadata:
         harness.metadata['title'] = Path(file_out).stem


### PR DESCRIPTION
- Solves #174 intermediately by allowing low level .gv tweaking.
- See https://github.com/formatc1702/WireViz/issues/174#issuecomment-707372543 and [HDMI_Sideband_Tap_tweaked.txt](https://github.com/formatc1702/WireViz/files/7130401/HDMI_Sideband_Tap_tweaked.txt) for an example usage and suggested changes of `syntax.md` for accepted input value types.
- This tweak feature is not limited to what I suggest in that example usage. It enables overriding any main attribute of any entry in the generated `.gv` file, and appending any number of custom entries, e.g. nodes, edges, and subgraphs. Overriding entries with attributes containing HTML is not tested, and will probably need more advanced functionality, but no such plans without any requests.
- Please check that attributes and custom entries are legal according to [The DOT Language](https://graphviz.org/doc/info/lang.html). Otherwise, Graphviz will issue error messages.
- ~~This PR also contains the commits from #214 and will probably need a rebase after #214 gets merged in.~~ (rebase done)
- Please try this feature by cloning my https://github.com/kvid/WireViz/tree/issue174-tweak branch and write a comment in this PR about your experience, but be aware that until this PR is merged into `dev`, I might change the contents of my branch at any time, including force-push that breaks old commit history.