### PR TITLE
Show connector pins even when all are unconnected

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -111,6 +111,10 @@ class Harness:
 
         for connector in self.connectors.values():
 
+            # If no wires connected (except maybe loop wires)?
+            if not (connector.ports_left or connector.ports_right):
+                connector.ports_left = True  # Use left side pins.
+
             html = []
 
             rows = [[remove_links(connector.name) if connector.show_name else None],


### PR DESCRIPTION
**Bug**: Hiding connector pins when none are connected is not reasonable. When combined with loops or neither pinlabels nor pincolors, then exceptions are raised as well.

**Fix**: Forcing pins at the left side in such cases solves #217.