### PR TITLE
Correctly check for show_wirenumbers default of None

### DIFF
--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -269,7 +269,7 @@ class Cable:
                     raise Exception('lists of part data are only supported for bundles')
 
         # by default, show wire numbers for cables, hide for bundles
-        if not self.show_wirenumbers:
+        if self.show_wirenumbers is None:
             self.show_wirenumbers = self.category != 'bundle'
 
         for i, item in enumerate(self.additional_components):


### PR DESCRIPTION
If `show_wirenumbers` is omitted from a cable section, its value will be `None`. In that case, we want to choose a default based on whether this is a bundle or not.

If the user did specify `show_wirenumbers`, then its value will be `True` or `False`, and we want to respect that whether it's a bundle or not.