### PR TITLE
Use unique index for connector pin ports

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Misc. fixes
 
+- Remove case-sensitivity issues with pin names and labels. ([#160](https://github.com/formatc1702/WireViz/issues/160), [#229](https://github.com/formatc1702/WireViz/pull/229))
 - Improve type hinting ([#156](https://github.com/formatc1702/WireViz/issues/156), [#163](https://github.com/formatc1702/WireViz/pull/163))
 - Move BOM management and HTML functions to separate modules ([#151](https://github.com/formatc1702/WireViz/issues/151), [#192](https://github.com/formatc1702/WireViz/pull/192))
 - Bug fixes ([#218](https://github.com/formatc1702/WireViz/pull/218), [#221](https://github.com/formatc1702/WireViz/pull/221))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,6 @@
 
 ## Misc. fixes
 
-- Remove case-sensitivity issues with pin names and labels. ([#160](https://github.com/formatc1702/WireViz/issues/160), [#229](https://github.com/formatc1702/WireViz/pull/229))
 - Improve type hinting ([#156](https://github.com/formatc1702/WireViz/issues/156), [#163](https://github.com/formatc1702/WireViz/pull/163))
 - Move BOM management and HTML functions to separate modules ([#151](https://github.com/formatc1702/WireViz/issues/151), [#192](https://github.com/formatc1702/WireViz/pull/192))
 - Bug fixes ([#218](https://github.com/formatc1702/WireViz/pull/218), [#221](https://github.com/formatc1702/WireViz/pull/221))

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -95,8 +95,8 @@ class Connector:
     pincount: Optional[int] = None
     image: Optional[Image] = None
     notes: Optional[MultilineHypertext] = None
-    pinlabels: List[Pin] = field(default_factory=list)
     pins: List[Pin] = field(default_factory=list)
+    pinlabels: List[Pin] = field(default_factory=list)
     pincolors: List[Color] = field(default_factory=list)
     color: Optional[Color] = None
     show_name: Optional[bool] = None

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -25,8 +25,9 @@ ColorScheme = PlainText # Color scheme name = Literal[wv_colors.COLOR_CODES.keys
 # Type combinations
 Colors = PlainText # One or more two-letter color names (Color) concatenated into one string
 Pin = Union[int, PlainText] # Pin identifier
+PinIndex = int # Zero-based pin index
 Wire = Union[int, PlainText] # Wire number or Literal['s'] for shield
-NoneOrMorePins = Union[Pin, Tuple[Pin, ...], None] # None, one, or a tuple of pins
+NoneOrMorePinIndices = Union[PinIndex, Tuple[PinIndex, ...], None]  # None, one, or a tuple of zero-based pin indices
 OneOrMoreWires = Union[Wire, Tuple[Wire, ...]] # One or a tuple of wires
 
 
@@ -277,8 +278,8 @@ class Cable:
                 self.additional_components[i] = AdditionalComponent(**item)
 
     # The *_pin arguments accept a tuple, but it seems not in use with the current code.
-    def connect(self, from_name: Optional[Designator], from_pin: NoneOrMorePins, via_wire: OneOrMoreWires,
-                to_name: Optional[Designator], to_pin: NoneOrMorePins) -> None:
+    def connect(self, from_name: Optional[Designator], from_pin: NoneOrMorePinIndices, via_wire: OneOrMoreWires,
+                to_name: Optional[Designator], to_pin: NoneOrMorePinIndices) -> None:
         from_pin = int2tuple(from_pin)
         via_wire = int2tuple(via_wire)
         to_pin = int2tuple(to_pin)
@@ -305,7 +306,7 @@ class Cable:
 @dataclass
 class Connection:
     from_name: Optional[Designator]
-    from_port: Optional[Pin]
+    from_port: Optional[PinIndex]
     via_port: Wire
     to_name: Optional[Designator]
-    to_port: Optional[Pin]
+    to_port: Optional[PinIndex]

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -78,7 +78,10 @@ class Harness:
                     raise Exception(f'{via_name}:{via_wire} is used for more than one wire.')
                 via_wire = cable.wirelabels.index(via_wire) + 1  # list index starts at 0, wire IDs start at 1
 
-        self.cables[via_name].connect(from_name, from_pin, via_wire, to_name, to_pin)
+        from_pin_id = self.connectors[from_name].pins.index(from_pin) if from_pin is not None else None
+        to_pin_id = self.connectors[to_name].pins.index(to_pin) if to_pin is not None else None
+
+        self.cables[via_name].connect(from_name, from_pin_id, via_wire, to_name, to_pin_id)
         if from_name in self.connectors:
             self.connectors[from_name].activate_pin(from_pin)
         if to_name in self.connectors:
@@ -135,12 +138,12 @@ class Harness:
                 pinhtml = []
                 pinhtml.append('<table border="0" cellspacing="0" cellpadding="3" cellborder="1">')
 
-                for pin, pinlabel, pincolor in zip_longest(connector.pins, connector.pinlabels, connector.pincolors):
-                    if connector.hide_disconnected_pins and not connector.visible_pins.get(pin, False):
+                for pinid, (pinname, pinlabel, pincolor) in enumerate(zip_longest(connector.pins, connector.pinlabels, connector.pincolors)):
+                    if connector.hide_disconnected_pins and not connector.visible_pins.get(pinname, False):
                         continue
                     pinhtml.append('   <tr>')
                     if connector.ports_left:
-                        pinhtml.append(f'    <td port="p{pin}l">{pin}</td>')
+                        pinhtml.append(f'    <td port="p{pinid}l">{pinname}</td>')
                     if pinlabel:
                         pinhtml.append(f'    <td>{pinlabel}</td>')
                     if connector.pincolors:
@@ -155,7 +158,7 @@ class Harness:
                             pinhtml.append( '    <td colspan="2"></td>')
 
                     if connector.ports_right:
-                        pinhtml.append(f'    <td port="p{pin}r">{pin}</td>')
+                        pinhtml.append(f'    <td port="p{pinid}r">{pinname}</td>')
                     pinhtml.append('   </tr>')
 
                 pinhtml.append('  </table>')
@@ -303,9 +306,9 @@ class Harness:
                     code_left_2 = f'{cable.name}:w{connection.via_port}:w'
                     dot.edge(code_left_1, code_left_2)
                     if from_connector.show_name:
-                        from_info = [str(connection.from_name), str(connection.from_port)]
+                        from_info = [str(connection.from_name), str(self.connectors[connection.from_name].pins[connection.from_port])]
                         if from_connector.pinlabels:
-                            pinlabel = from_connector.pinlabels[from_connector.pins.index(connection.from_port)]
+                            pinlabel = from_connector.pinlabels[connection.from_port]
                             if pinlabel != '':
                                 from_info.append(pinlabel)
                         from_string = ':'.join(from_info)
@@ -319,9 +322,9 @@ class Harness:
                     code_right_2 = f'{connection.to_name}{to_port}:w'
                     dot.edge(code_right_1, code_right_2)
                     if to_connector.show_name:
-                        to_info = [str(connection.to_name), str(connection.to_port)]
+                        to_info = [str(connection.to_name), str(self.connectors[connection.to_name].pins[connection.to_port])]
                         if to_connector.pinlabels:
-                            pinlabel = to_connector.pinlabels[to_connector.pins.index(connection.to_port)]
+                            pinlabel = to_connector.pinlabels[connection.to_port]
                             if pinlabel != '':
                                 to_info.append(pinlabel)
                         to_string = ':'.join(to_info)

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -143,7 +143,7 @@ class Harness:
                         continue
                     pinhtml.append('   <tr>')
                     if connector.ports_left:
-                        pinhtml.append(f'    <td port="p{pinid}l">{pinname}</td>')
+                        pinhtml.append(f'    <td port="p{pinid+1}l">{pinname}</td>')
                     if pinlabel:
                         pinhtml.append(f'    <td>{pinlabel}</td>')
                     if connector.pincolors:
@@ -158,7 +158,7 @@ class Harness:
                             pinhtml.append( '    <td colspan="2"></td>')
 
                     if connector.ports_right:
-                        pinhtml.append(f'    <td port="p{pinid}r">{pinname}</td>')
+                        pinhtml.append(f'    <td port="p{pinid+1}r">{pinname}</td>')
                     pinhtml.append('   </tr>')
 
                 pinhtml.append('  </table>')
@@ -301,7 +301,7 @@ class Harness:
                     dot.attr('edge', color=':'.join(['#000000', shield_color_hex, '#000000']) if isinstance(cable.shield, str) else '#000000')
                 if connection.from_port is not None:  # connect to left
                     from_connector = self.connectors[connection.from_name]
-                    from_port = f':p{connection.from_port}r' if from_connector.style != 'simple' else ''
+                    from_port = f':p{connection.from_port+1}r' if from_connector.style != 'simple' else ''
                     code_left_1 = f'{connection.from_name}{from_port}:e'
                     code_left_2 = f'{cable.name}:w{connection.via_port}:w'
                     dot.edge(code_left_1, code_left_2)
@@ -318,7 +318,7 @@ class Harness:
                 if connection.to_port is not None:  # connect to right
                     to_connector = self.connectors[connection.to_name]
                     code_right_1 = f'{cable.name}:w{connection.via_port}:e'
-                    to_port = f':p{connection.to_port}l' if self.connectors[connection.to_name].style != 'simple' else ''
+                    to_port = f':p{connection.to_port+1}l' if self.connectors[connection.to_name].style != 'simple' else ''
                     code_right_2 = f'{connection.to_name}{to_port}:w'
                     dot.edge(code_right_1, code_right_2)
                     if to_connector.show_name:

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -138,12 +138,12 @@ class Harness:
                 pinhtml = []
                 pinhtml.append('<table border="0" cellspacing="0" cellpadding="3" cellborder="1">')
 
-                for pinid, (pinname, pinlabel, pincolor) in enumerate(zip_longest(connector.pins, connector.pinlabels, connector.pincolors)):
+                for pinindex, (pinname, pinlabel, pincolor) in enumerate(zip_longest(connector.pins, connector.pinlabels, connector.pincolors)):
                     if connector.hide_disconnected_pins and not connector.visible_pins.get(pinname, False):
                         continue
                     pinhtml.append('   <tr>')
                     if connector.ports_left:
-                        pinhtml.append(f'    <td port="p{pinid+1}l">{pinname}</td>')
+                        pinhtml.append(f'    <td port="p{pinindex+1}l">{pinname}</td>')
                     if pinlabel:
                         pinhtml.append(f'    <td>{pinlabel}</td>')
                     if connector.pincolors:
@@ -158,7 +158,7 @@ class Harness:
                             pinhtml.append( '    <td colspan="2"></td>')
 
                     if connector.ports_right:
-                        pinhtml.append(f'    <td port="p{pinid+1}r">{pinname}</td>')
+                        pinhtml.append(f'    <td port="p{pinindex+1}r">{pinname}</td>')
                     pinhtml.append('   </tr>')
 
                 pinhtml.append('  </table>')


### PR DESCRIPTION
Closes #160.

Use unique numerical index instead of string (which might cause issues when using pin names that are not unique when ignoring upper/lower case).

This does not address the issue of having special HTML characters as part of pin names, labels, etc. [as mentioned in #160](https://github.com/formatc1702/WireViz/issues/160#issuecomment-725544366) and now listed as #230; there should be a separate PR dealing with escaping these entities in the GraphViz HTML (e.g. `>` to `&gt;`).