### PR TITLE
Improve gracefulness when invoking `wireviz.parse()` without `file_out` argument

### DIFF
--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -40,8 +40,13 @@ def parse(yaml_input: str, file_out: (str, Path) = None, return_types: (None, st
         options = Options(**yaml_data.get('options', {})),
         tweak = Tweak(**yaml_data.get('tweak', {})),
     )
+
+    # When title is not given, either deduce it from filename, or use default text.
     if 'title' not in harness.metadata:
-        harness.metadata['title'] = Path(file_out).stem
+        if file_out is None:
+            harness.metadata['title'] = "WireViz diagram and BOM"
+        else:
+            harness.metadata['title'] = Path(file_out).stem
 
     # add items
     sections = ['connectors', 'cables', 'connections']


### PR DESCRIPTION
Hi Daniel,

this patch would be a fix for the regression we reported and would resolve #253. Let me know what you think about it.

With kind regards,
Andreas.