### PR TITLE
Added option to set the dpi of the output

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -387,6 +387,9 @@ If any component is defined in the `connectors` or `cables` sections but not ref
   # about additional components inside the diagram node (connector/cable box).
   # If False, show all info about additional components inside the diagram node.
   mini_bom_mode: <bool>        # Default = True
+
+  # DPI setting for image outputs, https://graphviz.org/docs/attrs/dpi/
+  output_dpi: <float>          # Default 96.0
 ```
 
 

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -58,6 +58,7 @@ class Options:
     color_mode: ColorMode = "SHORT"
     mini_bom_mode: bool = True
     template_separator: str = "."
+    output_dpi: Optional[float] = 96.0
 
     def __post_init__(self):
         if not self.bgcolor_node:

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -172,6 +172,7 @@ class Harness:
             bgcolor=wv_colors.translate_color(self.options.bgcolor, "HEX"),
             nodesep="0.33",
             fontname=self.options.fontname,
+            dpi = f'{self.options.output_dpi}',
         )
         dot.attr(
             "node",


### PR DESCRIPTION
This adds the option 'output_dpi' for the user. This is used to set the 'dpi' of the output, the default is 96 which is also the default GraphViz default. https://graphviz.org/docs/attrs/dpi/

This comes from my annoyance that the text is kind of pixelated with 96dpi and having the option for higher res pictures is nice