### PR TITLE
Accept different YAML types for image(s)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,29 +4,32 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 6
       matrix:
-        python-version: [3.7, 3.8]
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@v1
+      uses: ts-graphviz/setup-graphviz@v2
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install .
     - name: Create Examples
-      run: PYTHONPATH=$(pwd)/src:$PYTHONPATH cd src/wireviz/ && python build_examples.py
+      run: PYTHONPATH=$(pwd)/src/wireviz:$PYTHONPATH cd src/wireviz/ && python build_examples.py
     - name: Upload examples, demos, and tutorials
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: examples-and-tutorials
+        name: examples-and-tutorials-v${{ matrix.python-version }}
         path: |
           examples/
           tutorial/
+        if-no-files-found: error
+        

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -113,6 +113,21 @@ class Image:
                 if self.width:
                     self.height = self.width / aspect_ratio(self.src)
 
+    @classmethod
+    def create(cls, input: Union[None, dict, str, List[Union[dict, str]]]):
+        """Create class instance(s) from alternative YAML input types"""
+        if input in (None, "", []):
+            return None
+        if isinstance(input, list):
+            return [cls.create(entry) for entry in input]
+        if isinstance(input, str):
+            input = {"src": input}
+        if isinstance(input, dict):
+            return cls(**input)
+        raise TypeError(
+            f"Expected None, dict, str, or list as Image input, but got {type(input)}"
+        )
+
 
 @dataclass
 class AdditionalComponent:
@@ -165,8 +180,7 @@ class Connector:
     additional_components: List[AdditionalComponent] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        if isinstance(self.image, dict):
-            self.image = Image(**self.image)
+        self.image = Image.create(self.image)
 
         self.ports_left = False
         self.ports_right = False
@@ -274,8 +288,7 @@ class Cable:
     additional_components: List[AdditionalComponent] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        if isinstance(self.image, dict):
-            self.image = Image(**self.image)
+        self.image = Image.create(self.image)
 
         if isinstance(self.gauge, str):  # gauge and unit specified
             try:

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -34,9 +34,8 @@ from wireviz.wv_colors import get_color_hex, translate_color
 from wireviz.wv_gv_html import (
     html_bgcolor,
     html_bgcolor_attr,
-    html_caption,
     html_colorbar,
-    html_image,
+    html_image_rows,
     html_line_breaks,
     nested_html_table,
     remove_links,
@@ -203,8 +202,7 @@ class Harness:
                      translate_color(connector.color, self.options.color_mode) if connector.color else None,
                      html_colorbar(connector.color)],
                     '<!-- connector table -->' if connector.style != 'simple' else None,
-                    [html_image(connector.image)],
-                    [html_caption(connector.image)]]
+                    *html_image_rows(connector.image)]
             # fmt: on
 
             rows.extend(get_additional_component_table(self, connector))
@@ -326,8 +324,7 @@ class Harness:
                      translate_color(cable.color, self.options.color_mode) if cable.color else None,
                      html_colorbar(cable.color)],
                     '<!-- wire table -->',
-                    [html_image(cable.image)],
-                    [html_caption(cable.image)]]
+                    *html_image_rows(cable.image)]
             # fmt: on
 
             rows.extend(get_additional_component_table(self, cable))

--- a/src/wireviz/wv_gv_html.py
+++ b/src/wireviz/wv_gv_html.py
@@ -64,6 +64,12 @@ def html_colorbar(color: Color) -> str:
     return html_bgcolor(color, ' width="4"') if color else None
 
 
+def html_image_rows(image):
+    from wireviz.wv_bom import make_list
+
+    return sum([[[html_image(i)], [html_caption(i)]] for i in make_list(image)], [])
+
+
 def html_image(image):
     from wireviz.DataClasses import Image
 


### PR DESCRIPTION
- [x] Accept a single string - fixes #292
- [x] Accept a list of images - fixes #407
- [x] Accept no image (as today) - also consider empty string/list as none
- [x] Accept dict (as today)
- [x] Raise TypeError for unexpected input types
- [ ] TODO: The current implementation of resolving image paths would require checking all the different input types twice: 1) in the `parse()` function to find and resolve the paths (not yet fully implemented), and 2) in `Image.create()` to create the instance(s). How can this be simplified by e.g. forwarding the context (with image path list) to `Image.create()` to avoid duplicating all the type testing?
- [ ] TODO: After #420 is merged in, we must also handle different image positions in a list of images, and internally maybe split them into one list per possible position.
- [ ] TODO: This PR is currently based on `master` to simplify testing the concept, but will later be rebased onto `dev` and the single commit about HTML generation adapted to #251.