### PR TITLE
Add SVG Mime Type

### DIFF
--- a/src/wireviz/svgembed.py
+++ b/src/wireviz/svgembed.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 from typing import Union
 
-mime_subtype_replacements = {"jpg": "jpeg", "tif": "tiff"}
+mime_subtype_replacements = {"jpg": "jpeg", "svg": "svg+xml", "tif": "tiff"}
 
 
 # TODO: Share cache and code between data_URI_base64() and embed_svg_images()


### PR DESCRIPTION
When attempting to add SVG images to connectors and cables, they failed to show up even though the base64 content was correct in the HTML and SVG outputs.
Checking https://www.w3.org/TR/SVG11/intro.html reveals the mime type should be image/svg+xml, not image/svg.
As the code already handles mime subtype replacements for jpeg and tiff, adding svg here made for a simple fix.
