### PR TITLE
Fix template search path

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -70,6 +70,7 @@ class Harness:
     metadata: Metadata
     options: Options
     tweak: Tweak
+    source_path: Path
 
     def __post_init__(self):
         self.connectors = {}
@@ -697,7 +698,7 @@ class Harness:
             print("CSV output is not yet supported")
         # HTML output
         if "html" in fmt:
-            generate_html_output(filename, bomlist, self.metadata, self.options)
+            generate_html_output(filename, bomlist, self.metadata, self.options, self.source_path)
         # PDF output
         if "pdf" in fmt:
             # TODO: implement PDF output

--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -31,6 +31,7 @@ def parse(
     output_dir: Union[str, Path] = None,
     output_name: Union[None, str] = None,
     image_paths: Union[Path, str, List] = [],
+    source_path = None,
 ) -> Any:
     """
     This function takes an input, parses it as a WireViz Harness file,
@@ -115,6 +116,7 @@ def parse(
         metadata=Metadata(**yaml_data.get("metadata", {})),
         options=Options(**yaml_data.get("options", {})),
         tweak=Tweak(**yaml_data.get("tweak", {})),
+        source_path=source_path
     )
     # others
     # store mapping of components to their respective template

--- a/src/wireviz/wv_cli.py
+++ b/src/wireviz/wv_cli.py
@@ -144,6 +144,7 @@ def wireviz(file, format, prepend, output_dir, output_name, version):
             output_dir=_output_dir,
             output_name=_output_name,
             image_paths=list(image_paths),
+            source_path=file
         )
 
     print()

--- a/src/wireviz/wv_html.py
+++ b/src/wireviz/wv_html.py
@@ -21,14 +21,19 @@ def generate_html_output(
     bom_list: List[List[str]],
     metadata: Metadata,
     options: Options,
+    source: Union[str, Path] = None,
 ):
     # load HTML template
     templatename = metadata.get("template", {}).get("name")
+    template_search_paths = [ Path(filename).parent, Path(__file__).parent / "templates"]
+
+    if source is not None:
+        template_search_paths.insert(0, Path(source).parent)
+
     if templatename:
         # if relative path to template was provided, check directory of YAML file first, fall back to built-in template directory
         templatefile = smart_file_resolve(
-            f"{templatename}.html",
-            [Path(filename).parent, Path(__file__).parent / "templates"],
+            f"{templatename}.html", template_search_paths
         )
     else:
         # fall back to built-in simple template if no template was provided


### PR DESCRIPTION
Addresses #472 

the source file path is now forwarded to the Harness object and on to the HTML generator code. Its the last argument with a default to keep API compatibility. Ive also kept the output-relative search location to avoid hurting anyone relying on that behavior