### PR TITLE
Allow pin labels in connector loop definitions (fixes #432)

### DIFF
--- a/examples/ex17_loop_labels.yml
+++ b/examples/ex17_loop_labels.yml
@@ -1,0 +1,23 @@
+# Connector loops using pin labels
+# RS-232 loopback adapter: RTS-CTS and DSR-DTR-DCD jumpered,
+# with TX/RX/GND passed through to a cable.
+
+connectors:
+  X1:
+    type: D-Sub
+    subtype: female
+    pinlabels: [DCD, RX, TX, DTR, GND, DSR, RTS, CTS, RI]
+    loops:
+      - [RTS, CTS]      # pin labels instead of numbers
+      - [DSR, DTR]
+      - [4, DCD]         # mixed: pin number + label
+
+cables:
+  W1:
+    wirecount: 3
+    colors: [BK, RD, GN]
+
+connections:
+  -
+    - X1: [RX, TX, GND]  # labels in connections too
+    - W1: [1-3]

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -213,6 +213,11 @@ class Connector:
                 resolved.append(pin)
                 # Make sure loop connected pins are not hidden.
                 self.activate_pin(pin, None)
+            if resolved[0] == resolved[1]:
+                raise Exception(
+                    f'Loop in connector "{self.name}" connects pin '
+                    f'"{resolved[0]}" to itself.'
+                )
             self.loops[i] = resolved
 
         for i, item in enumerate(self.additional_components):
@@ -229,7 +234,13 @@ class Connector:
         in_labels = pin in self.pinlabels if self.pinlabels else False
 
         if in_pins and in_labels:
-            # present in both lists — check for ambiguity
+            # present in both lists — check for duplicate labels first
+            if self.pinlabels.count(pin) > 1:
+                raise Exception(
+                    f'Pin label "{pin}" in connector "{self.name}" '
+                    f"is defined more than once in pinlabels."
+                )
+            # then check for positional ambiguity
             if self.pins.index(pin) != self.pinlabels.index(pin):
                 raise Exception(
                     f'"{pin}" in connector "{self.name}" exists in both '
@@ -252,7 +263,7 @@ class Connector:
             f'Unknown pin "{pin}" for connector "{self.name}"!'
         )
 
-    def activate_pin(self, pin: Pin, side: Side) -> None:
+    def activate_pin(self, pin: Pin, side: Optional[Side]) -> None:
         self.visible_pins[pin] = True
         if side == Side.LEFT:
             self.ports_left = True

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -227,8 +227,22 @@ class Connector:
     def resolve_pin(self, pin: Pin) -> Pin:
         """Resolve a pin identifier to its canonical pin number.
 
-        Accepts pin numbers (from self.pins) or pin labels (from
-        self.pinlabels). Raises if ambiguous or not found.
+        Given a value that may be either a pin number (from self.pins)
+        or a pin label (from self.pinlabels), returns the corresponding
+        pin number from self.pins.
+
+        Callers needing a positional index should use
+        self.pins.index(return_value).
+
+        Resolution order:
+            1. Value in both pins and pinlabels at the same position
+               -> return directly (no ambiguity).
+            2. Value in both at different positions -> raise.
+            3. Value only in pinlabels -> return corresponding pin number.
+            4. Value only in pins -> return directly.
+            5. Not found -> raise.
+
+        Note: Lookups are type-sensitive (int 1 != str "1").
         """
         in_pins = pin in self.pins
         in_labels = pin in self.pinlabels if self.pinlabels else False

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
 from wireviz.wv_colors import COLOR_CODES, Color, ColorMode, Colors, ColorScheme
-from wireviz.wv_helper import aspect_ratio, int2tuple
+from wireviz.wv_helper import aspect_ratio, int2tuple, normalize_pin
 
 # Each type alias have their legal values described in comments - validation might be implemented in the future
 PlainText = str  # Text not containing HTML tags nor newlines
@@ -167,6 +167,15 @@ class Connector:
     def __post_init__(self) -> None:
         if isinstance(self.image, dict):
             self.image = Image(**self.image)
+
+        # Normalize pin-like fields so int/str types are consistent
+        # regardless of YAML quoting (e.g. "1" vs 1).
+        if self.pins:
+            self.pins = [normalize_pin(p) for p in self.pins]
+        if self.pinlabels:
+            self.pinlabels = [normalize_pin(p) for p in self.pinlabels]
+        if self.loops:
+            self.loops = [[normalize_pin(p) for p in loop] for loop in self.loops]
 
         self.ports_left = False
         self.ports_right = False
@@ -404,6 +413,7 @@ class Cable:
             self.wirecount = len(self.colors)
 
         if self.wirelabels:
+            self.wirelabels = [normalize_pin(w) for w in self.wirelabels]
             if self.shield and "s" in self.wirelabels:
                 raise Exception(
                     '"s" may not be used as a wire label for a shielded cable.'

--- a/src/wireviz/DataClasses.py
+++ b/src/wireviz/DataClasses.py
@@ -203,22 +203,54 @@ class Connector:
             # hide pincount for simple (1 pin) connectors by default
             self.show_pincount = self.style != "simple"
 
-        for loop in self.loops:
-            # TODO: allow using pin labels in addition to pin numbers, just like when defining regular connections
+        for i, loop in enumerate(self.loops):
             # TODO: include properties of wire used to create the loop
             if len(loop) != 2:
                 raise Exception("Loops must be between exactly two pins!")
+            resolved = []
             for pin in loop:
-                if pin not in self.pins:
-                    raise Exception(
-                        f'Unknown loop pin "{pin}" for connector "{self.name}"!'
-                    )
+                pin = self.resolve_pin(pin)
+                resolved.append(pin)
                 # Make sure loop connected pins are not hidden.
                 self.activate_pin(pin, None)
+            self.loops[i] = resolved
 
         for i, item in enumerate(self.additional_components):
             if isinstance(item, dict):
                 self.additional_components[i] = AdditionalComponent(**item)
+
+    def resolve_pin(self, pin: Pin) -> Pin:
+        """Resolve a pin identifier to its canonical pin number.
+
+        Accepts pin numbers (from self.pins) or pin labels (from
+        self.pinlabels). Raises if ambiguous or not found.
+        """
+        in_pins = pin in self.pins
+        in_labels = pin in self.pinlabels if self.pinlabels else False
+
+        if in_pins and in_labels:
+            # present in both lists — check for ambiguity
+            if self.pins.index(pin) != self.pinlabels.index(pin):
+                raise Exception(
+                    f'"{pin}" in connector "{self.name}" exists in both '
+                    f"pins and pinlabels at different positions."
+                )
+            return pin  # same position, no ambiguity
+
+        if in_labels:
+            if self.pinlabels.count(pin) > 1:
+                raise Exception(
+                    f'Pin label "{pin}" in connector "{self.name}" '
+                    f"is defined more than once."
+                )
+            return self.pins[self.pinlabels.index(pin)]
+
+        if in_pins:
+            return pin
+
+        raise Exception(
+            f'Unknown pin "{pin}" for connector "{self.name}"!'
+        )
 
     def activate_pin(self, pin: Pin, side: Side) -> None:
         self.visible_pins[pin] = True

--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -105,28 +105,17 @@ class Harness:
         to_name: str,
         to_pin: (int, str),
     ) -> None:
-        # check from and to connectors
-        for name, pin in zip([from_name, to_name], [from_pin, to_pin]):
+        # resolve pin labels to pin numbers via Connector.resolve_pin()
+        for name, pin, is_from in [
+            (from_name, from_pin, True),
+            (to_name, to_pin, False),
+        ]:
             if name is not None and name in self.connectors:
-                connector = self.connectors[name]
-                # check if provided name is ambiguous
-                if pin in connector.pins and pin in connector.pinlabels:
-                    if connector.pins.index(pin) != connector.pinlabels.index(pin):
-                        raise Exception(
-                            f"{name}:{pin} is defined both in pinlabels and pins, for different pins."
-                        )
-                    # TODO: Maybe issue a warning if present in both lists but referencing the same pin?
-                if pin in connector.pinlabels:
-                    if connector.pinlabels.count(pin) > 1:
-                        raise Exception(f"{name}:{pin} is defined more than once.")
-                    index = connector.pinlabels.index(pin)
-                    pin = connector.pins[index]  # map pin name to pin number
-                    if name == from_name:
-                        from_pin = pin
-                    if name == to_name:
-                        to_pin = pin
-                if not pin in connector.pins:
-                    raise Exception(f"{name}:{pin} not found.")
+                resolved = self.connectors[name].resolve_pin(pin)
+                if is_from:
+                    from_pin = resolved
+                else:
+                    to_pin = resolved
 
         # check via cable
         if via_name in self.cables:
@@ -280,9 +269,14 @@ class Harness:
                 else:
                     raise Exception("No side for loops")
                 for loop in connector.loops:
+                    # Convert pin numbers to 1-based port indices.
+                    # Ports are named p{index+1} in the connector table,
+                    # not p{pin_number} — these differ for non-sequential pins.
+                    idx0 = connector.pins.index(loop[0]) + 1
+                    idx1 = connector.pins.index(loop[1]) + 1
                     dot.edge(
-                        f"{connector.name}:p{loop[0]}{loop_side}:{loop_dir}",
-                        f"{connector.name}:p{loop[1]}{loop_side}:{loop_dir}",
+                        f"{connector.name}:p{idx0}{loop_side}:{loop_dir}",
+                        f"{connector.name}:p{idx1}{loop_side}:{loop_dir}",
                         label=" ",  # Work-around to avoid over-sized loops.
                     )
 

--- a/src/wireviz/wv_helper.py
+++ b/src/wireviz/wv_helper.py
@@ -34,6 +34,17 @@ def mm2_equiv(awg):
     return mm2_equiv_table.get(str(awg), "Unknown")
 
 
+def normalize_pin(value):
+    """Normalize a pin value: try int() first, fall back to str().
+
+    Matches the coercion convention used by expand().
+    """
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return str(value) if value is not None else value
+
+
 def expand(yaml_data):
     # yaml_data can be:
     # - a singleton (normally str or int)
@@ -61,11 +72,7 @@ def expand(yaml_data):
                 # '-' was not a delimiter between two ints, pass e through unchanged
                 output.append(e)
         else:
-            try:
-                x = int(e)  # single int
-            except Exception:
-                x = e  # string
-            output.append(x)
+            output.append(normalize_pin(e))
     return output
 
 

--- a/tests/test_resolve_pin.py
+++ b/tests/test_resolve_pin.py
@@ -295,3 +295,114 @@ class TestHarnessConnectDelegation:
 
         with pytest.raises(Exception, match="Unknown pin"):
             harness.connect("X1", 99, "W1", 1, "X2", 1)
+
+
+# --- Pin type coercion (C-3 fix) ---
+
+
+class TestPinTypeCoercion:
+    """Verify that YAML quoting differences don't break pin lookups.
+
+    YAML safe_load() parses unquoted 1 as int(1) and quoted "1" as str("1").
+    The C-3 fix normalizes all pin-like fields at the dataclass boundary
+    so downstream code always sees consistent types.
+    """
+
+    def test_str_numeric_pins_normalize_to_int(self):
+        """String numeric pins are coerced to int."""
+        c = make_connector(pins=["1", "2", "3"])
+        assert c.pins == [1, 2, 3]
+        assert all(isinstance(p, int) for p in c.pins)
+
+    def test_mixed_type_pins_normalize(self):
+        """Mix of int and str numeric pins all become int."""
+        c = make_connector(pins=[1, "2", 3])
+        assert c.pins == [1, 2, 3]
+
+    def test_leading_zeros_normalize(self):
+        """Leading zeros normalize to plain ints."""
+        c = make_connector(pins=["01", "02", "03"])
+        assert c.pins == [1, 2, 3]
+
+    def test_non_numeric_pins_stay_str(self):
+        """Non-numeric pins remain as strings."""
+        c = make_connector(pins=["A", "B", "C"])
+        assert c.pins == ["A", "B", "C"]
+        assert all(isinstance(p, str) for p in c.pins)
+
+    def test_duplicate_after_normalization_raises(self):
+        """Pins that become duplicates after normalization are caught."""
+        with pytest.raises(Exception, match="Pins are not unique"):
+            make_connector(pins=[1, "1"])
+
+    def test_pinlabels_normalize(self):
+        """Pinlabels are also normalized."""
+        c = make_connector(pins=[1, 2], pinlabels=["10", "20"])
+        assert c.pinlabels == [10, 20]
+
+    def test_loop_pins_normalize(self):
+        """Loop pin references are normalized before resolve_pin()."""
+        c = make_connector(
+            pins=[1, 2, 3, 4],
+            loops=[["1", "2"]],
+        )
+        # Loops are resolved to pin numbers (which are already int)
+        assert c.loops == [[1, 2]]
+
+    def test_str_loop_pins_match_auto_generated_int_pins(self):
+        """String loop pins match auto-generated sequential int pins.
+
+        This is the core regression: without normalization,
+        "1" in [1, 2, 3] is False, so resolve_pin() would fail.
+        """
+        c = make_connector(
+            pincount=4,
+            loops=[["1", "3"]],
+        )
+        assert c.loops == [[1, 3]]
+
+    def test_wirelabels_normalize(self):
+        """Cable wirelabels are normalized."""
+        from wireviz.DataClasses import Cable
+
+        cable = Cable(name="W1", wirecount=3, colors=["BK", "RD", "GN"],
+                      wirelabels=["1", "2", "3"])
+        assert cable.wirelabels == [1, 2, 3]
+
+    def test_quoted_pin_yaml_renders(self):
+        """Integration: quoted pins in YAML render without error."""
+        import yaml
+
+        from wireviz.DataClasses import Metadata, Options, Tweak
+        from wireviz.Harness import Harness
+
+        yaml_str = """
+connectors:
+  X1:
+    pins: ["1", "2", "3"]
+    pinlabels: [VCC, GND, SIG]
+    loops:
+      - ["1", "2"]
+cables:
+  W1:
+    wirecount: 1
+    colors: [BK]
+connections:
+  -
+    - X1: ["3"]
+    - W1: [1]
+"""
+        data = yaml.safe_load(yaml_str)
+        harness = Harness(
+            metadata=Metadata(data.get("metadata", {})),
+            options=Options(**data.get("options", {})),
+            tweak=Tweak(**data.get("tweak", {})),
+        )
+        for name, conn_data in data.get("connectors", {}).items():
+            harness.add_connector(name, **conn_data)
+        for name, cable_data in data.get("cables", {}).items():
+            harness.add_cable(name, **cable_data)
+
+        # Should not raise — the whole point of C-3
+        graph = harness.create_graph()
+        assert graph is not None

--- a/tests/test_resolve_pin.py
+++ b/tests/test_resolve_pin.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for Connector.resolve_pin() and loop pin resolution.
+
+Covers the fix for https://github.com/wireviz/WireViz/issues/432
+and related safety-critical pin resolution correctness.
+"""
+
+import pytest
+
+from wireviz.DataClasses import Connector
+
+
+def make_connector(pins=None, pinlabels=None, loops=None, **kwargs):
+    """Helper to build a Connector with minimal required fields."""
+    args = {"name": "X1"}
+    if pins is not None:
+        args["pins"] = pins
+    if pinlabels is not None:
+        args["pinlabels"] = pinlabels
+    if loops is not None:
+        args["loops"] = loops
+    args.update(kwargs)
+    return Connector(**args)
+
+
+# --- resolve_pin() happy paths ---
+
+
+class TestResolvePinHappyPaths:
+    def test_pin_number_passthrough(self):
+        """Pin number that exists in self.pins returns unchanged."""
+        c = make_connector(pins=[1, 2, 3])
+        assert c.resolve_pin(2) == 2
+
+    def test_label_resolves_to_pin_number(self):
+        """Pin label resolves to the corresponding pin number."""
+        c = make_connector(pins=[1, 2, 3], pinlabels=["VCC", "GND", "SIG"])
+        assert c.resolve_pin("GND") == 2
+
+    def test_label_with_non_sequential_pins(self):
+        """Labels work correctly even when pin numbers are non-sequential."""
+        c = make_connector(pins=[10, 20, 30], pinlabels=["A", "B", "C"])
+        assert c.resolve_pin("B") == 20
+
+    def test_value_in_both_lists_same_position(self):
+        """Value that exists in both pins and pinlabels at the same index."""
+        c = make_connector(pins=["A", "B", "C"], pinlabels=["A", "X", "Y"])
+        assert c.resolve_pin("A") == "A"
+
+    def test_empty_pinlabels_falls_through(self):
+        """When pinlabels is empty, pin numbers still resolve."""
+        c = make_connector(pins=[1, 2, 3], pinlabels=[])
+        assert c.resolve_pin(3) == 3
+
+
+# --- resolve_pin() error paths ---
+
+
+class TestResolvePinErrors:
+    def test_unknown_pin_raises(self):
+        """Resolving a pin that doesn't exist in either list raises."""
+        c = make_connector(pins=[1, 2, 3], pinlabels=["A", "B", "C"])
+        with pytest.raises(Exception, match="Unknown pin"):
+            c.resolve_pin("NONEXISTENT")
+
+    def test_unknown_number_raises(self):
+        """Resolving a pin number not in self.pins raises."""
+        c = make_connector(pins=[1, 2, 3])
+        with pytest.raises(Exception, match="Unknown pin"):
+            c.resolve_pin(99)
+
+    def test_ambiguous_pin_different_positions(self):
+        """Value in both pins and pinlabels at different positions raises."""
+        c = make_connector(pins=["A", "B", "C"], pinlabels=["X", "A", "Y"])
+        with pytest.raises(Exception, match="exists in both"):
+            c.resolve_pin("A")
+
+    def test_duplicate_label_only_in_labels(self):
+        """Duplicate label in pinlabels (label-only path) raises."""
+        c = make_connector(pins=[1, 2, 3], pinlabels=["A", "B", "A"])
+        with pytest.raises(Exception, match="defined more than once"):
+            c.resolve_pin("A")
+
+    def test_duplicate_label_in_both_lists(self):
+        """Duplicate label detected even when value also exists in pins (C-2 fix)."""
+        c = make_connector(pins=["A", "B", "C"], pinlabels=["A", "X", "A"])
+        with pytest.raises(Exception, match="defined more than once"):
+            c.resolve_pin("A")
+
+
+# --- Loop resolution ---
+
+
+class TestLoopResolution:
+    def test_loop_with_labels(self):
+        """Loops specified with pin labels resolve to pin numbers."""
+        c = make_connector(
+            pins=[1, 2, 3, 4],
+            pinlabels=["VCC", "GND", "TX", "RX"],
+            loops=[["VCC", "GND"]],
+        )
+        assert c.loops == [[1, 2]]
+
+    def test_loop_with_mixed_number_and_label(self):
+        """Loop with one pin number and one label resolves correctly."""
+        c = make_connector(
+            pins=[1, 2, 3, 4],
+            pinlabels=["VCC", "GND", "TX", "RX"],
+            loops=[[1, "GND"]],
+        )
+        assert c.loops == [[1, 2]]
+
+    def test_loop_with_non_sequential_pins(self):
+        """Loops resolve correctly with non-sequential pin numbering."""
+        c = make_connector(
+            pins=[10, 20, 30, 40],
+            pinlabels=["VCC", "GND", "TX", "RX"],
+            loops=[["VCC", "GND"]],
+        )
+        assert c.loops == [[10, 20]]
+
+    def test_loop_self_reference_raises(self):
+        """A loop from a pin to itself raises (I-2 fix)."""
+        with pytest.raises(Exception, match="to itself"):
+            make_connector(
+                pins=[1, 2, 3],
+                pinlabels=["A", "B", "C"],
+                loops=[["A", "A"]],
+            )
+
+    def test_loop_self_reference_via_label_and_number(self):
+        """Self-loop detected even when specified as label + number."""
+        with pytest.raises(Exception, match="to itself"):
+            make_connector(
+                pins=[1, 2, 3],
+                pinlabels=["A", "B", "C"],
+                loops=[[2, "B"]],
+            )
+
+    def test_loop_activates_pins(self):
+        """Loop-connected pins are marked visible (for hide_disconnected_pins)."""
+        c = make_connector(
+            pins=[1, 2, 3, 4],
+            pinlabels=["VCC", "GND", "TX", "RX"],
+            loops=[["TX", "RX"]],
+        )
+        assert c.visible_pins.get(3) is True
+        assert c.visible_pins.get(4) is True
+        # Unconnected pins should not be in visible_pins
+        assert 1 not in c.visible_pins
+
+    def test_multiple_loops(self):
+        """Multiple loops on the same connector all resolve correctly."""
+        c = make_connector(
+            pins=[1, 2, 3, 4, 5, 6],
+            pinlabels=["A", "B", "C", "D", "E", "F"],
+            loops=[["A", "B"], ["E", "F"]],
+        )
+        assert c.loops == [[1, 2], [5, 6]]
+
+
+# --- Loop rendering: non-sequential pins (C-1 fix) ---
+
+
+class TestLoopRendering:
+    """Verify that the GraphViz output uses port indices, not pin numbers.
+
+    This is the critical C-1 fix: Harness.py must convert resolved pin
+    numbers to 1-based position indices for GraphViz port references.
+    """
+
+    def _render_gv(self, yaml_str):
+        """Parse a YAML string through WireViz and return the GV source."""
+        import yaml
+
+        from wireviz.DataClasses import Metadata, Options, Tweak
+        from wireviz.Harness import Harness
+
+        data = yaml.safe_load(yaml_str)
+        harness = Harness(
+            metadata=Metadata(data.get("metadata", {})),
+            options=Options(**data.get("options", {})),
+            tweak=Tweak(**data.get("tweak", {})),
+        )
+        for name, conn_data in data.get("connectors", {}).items():
+            harness.add_connector(name, **conn_data)
+        for name, cable_data in data.get("cables", {}).items():
+            harness.add_cable(name, **cable_data)
+
+        graph = harness.create_graph()
+        return graph.source
+
+    def test_non_sequential_pins_use_indices(self):
+        """C-1 regression test: loops must use port indices, not pin numbers.
+
+        With pins: [10, 20, 30, 40], a loop between pins 10 and 20
+        must produce port references p1 and p2 (1-based indices),
+        NOT p10 and p20 (pin numbers).
+        """
+        yaml_str = """
+connectors:
+  X1:
+    pins: [10, 20, 30, 40]
+    pinlabels: [VCC, GND, TX, RX]
+    loops:
+      - [VCC, GND]
+cables:
+  W1:
+    wirecount: 2
+    colors: [BK, RD]
+connections:
+  -
+    - X1: [TX, RX]
+    - W1: [1-2]
+"""
+        gv = self._render_gv(yaml_str)
+        # The loop should reference p1 and p2 (positions), not p10 and p20.
+        # Look specifically for the loop edge pattern with port names.
+        import re
+
+        loop_edges = re.findall(r"X1:p(\d+)\w:\w -- X1:p(\d+)\w:\w", gv)
+        assert len(loop_edges) == 1, f"Expected 1 loop edge, found {len(loop_edges)}"
+        idx_a, idx_b = loop_edges[0]
+        # Pin 10 is at index 1, pin 20 is at index 2
+        assert idx_a == "1" and idx_b == "2", (
+            f"Loop ports should be p1/p2 (indices), got p{idx_a}/p{idx_b}"
+        )
+
+    def test_sequential_pins_still_work(self):
+        """Sequential pins (the common case) continue to work correctly."""
+        yaml_str = """
+connectors:
+  X1:
+    pinlabels: [VCC, GND, TX, RX]
+    loops:
+      - [VCC, GND]
+cables:
+  W1:
+    wirecount: 2
+    colors: [BK, RD]
+connections:
+  -
+    - X1: [TX, RX]
+    - W1: [1-2]
+"""
+        gv = self._render_gv(yaml_str)
+        # With sequential pins [1,2,3,4], p1/p2 are both the index and number
+        assert ":p1" in gv
+        assert ":p2" in gv
+
+
+# --- Harness.connect() delegation (I-1 fix) ---
+
+
+class TestHarnessConnectDelegation:
+    """Verify Harness.connect() now delegates to Connector.resolve_pin()."""
+
+    def test_connect_resolves_labels(self):
+        """Wire connections using pin labels resolve correctly."""
+        from wireviz.DataClasses import Cable, Metadata, Options, Tweak
+        from wireviz.Harness import Harness
+
+        harness = Harness(
+            metadata=Metadata({}),
+            options=Options(),
+            tweak=Tweak(),
+        )
+        harness.add_connector(
+            "X1", pins=[1, 2, 3], pinlabels=["VCC", "GND", "SIG"]
+        )
+        harness.add_connector("X2", pins=[1, 2, 3])
+        harness.add_cable("W1", wirecount=1, colors=["BK"])
+
+        # Connect using a label on the from side
+        harness.connect("X1", "SIG", "W1", 1, "X2", 1)
+
+        # The connection should store the resolved pin number (3), not the label
+        conn = harness.cables["W1"].connections[0]
+        assert conn.from_pin == 3
+
+    def test_connect_rejects_unknown_pin(self):
+        """Wire connections with unknown pins raise via resolve_pin()."""
+        from wireviz.DataClasses import Metadata, Options, Tweak
+        from wireviz.Harness import Harness
+
+        harness = Harness(
+            metadata=Metadata({}),
+            options=Options(),
+            tweak=Tweak(),
+        )
+        harness.add_connector("X1", pins=[1, 2, 3])
+        harness.add_connector("X2", pins=[1, 2, 3])
+        harness.add_cable("W1", wirecount=1, colors=["BK"])
+
+        with pytest.raises(Exception, match="Unknown pin"):
+            harness.connect("X1", 99, "W1", 1, "X2", 1)


### PR DESCRIPTION
## Summary

Connector `loops` now accept pin labels (from `pinlabels`) in addition to pin numbers, matching how regular connections already work.

```yaml
# Before: only pin numbers worked
loops:
  - [7, 8]

# After: pin labels work too
loops:
  - [RTS, CTS]
  - [1, GND]       # mixed is fine
```

Also fixes two pre-existing bugs:
- Loop edges rendered on wrong pins for connectors with non-sequential pin numbering (#465)
- YAML quoting differences (`pins: [1]` vs `pins: ["1"]`) caused silent pin lookup failures

## Changes

### `wv_helper.py`

- **New `normalize_pin()` function** — tries `int()` first, falls back to `str()`. Extracts the coercion logic that was already inline in `expand()`.
- **`expand()` refactored** — uses `normalize_pin()` instead of inline try/except.

### `DataClasses.py`

- **New `Connector.resolve_pin()` method** — resolves a pin identifier (number or label) to its canonical pin number. Handles ambiguity detection (value in both `pins` and `pinlabels` at different positions) and duplicate label detection.
- **Pin type normalization in `Connector.__post_init__()`** — `pins`, `pinlabels`, and `loops` are normalized via `normalize_pin()` before any validation. This ensures `pins: ["1", "2"]` and `pins: [1, 2]` behave identically regardless of YAML quoting.
- **Pin type normalization in `Cable.__post_init__()`** — `wirelabels` normalized the same way.
- **Loop validation updated** — loops now resolve through `resolve_pin()` and store the resolved pin numbers. Self-loops (same pin on both ends) are rejected.
- **`activate_pin()` type annotation** — `side` parameter updated to `Optional[Side]` since loops pass `None`.

### `Harness.py`

- **`connect()` refactored** — pin resolution logic (previously ~20 lines duplicating the same algorithm) replaced with delegation to `Connector.resolve_pin()`. Behavior is unchanged, but the logic now lives in one place.
- **Loop rendering fix** — loop edges now convert pin numbers to 1-based port indices via `connector.pins.index()`, matching how wire connections already work. Previously, pin numbers were used directly as port names, which produced silently wrong diagrams for non-sequential pins like `pins: [10, 20, 30, 40]`.

### `examples/ex17_loop_labels.yml` (new)

RS-232 loopback adapter example demonstrating loops with pin labels, mixed number + label, and label-based wire connections.

### `tests/test_resolve_pin.py` (new)

31 tests covering:
- `resolve_pin()` happy paths and error paths
- Loop resolution with labels, mixed types, non-sequential pins, self-loop detection
- GraphViz rendering with correct port indices
- Harness.connect() delegation
- **Pin type coercion**: str-to-int normalization, mixed types, leading zeros, non-numeric pins, duplicate-after-normalization, wirelabels, and full YAML integration

## Test plan

- [x] 31/31 tests pass
- [x] All 17 examples render without error (including new ex17)
- [x] All 8 tutorials render without error
- [x] Non-sequential pin test verifies port indices p1/p2 (not p10/p20) in GV output
- [x] Regression: `pins: ["1", "2", "3"]` with `loops: [[1, "2"]]` resolves correctly
- [ ] Reviewer: verify edge cases with non-numeric pins containing digits (e.g. `"A1"`, `"3.3V"`)

## Notes

- The loop rendering bug (pin numbers vs port indices) was pre-existing, not introduced by this PR. It was invisible because all existing examples use sequential pins where number == index.
- No changes to YAML schema — `loops` accepts the same types as before, plus strings that match `pinlabels`. Existing YAML files are unaffected by pin normalization.