### PR TITLE
Handle different color specifiers

### DIFF
--- a/src/wireviz/Harness.py
+++ b/src/wireviz/Harness.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, List, Union
 
 from graphviz import Graph
+
 from wireviz import APP_NAME, APP_URL, __version__, wv_colors
 from wireviz.DataClasses import (
     Cable,
@@ -289,7 +290,7 @@ class Harness:
         # determine if there are double- or triple-colored wires in the harness;
         # if so, pad single-color wires to make all wires of equal thickness
         pad = any(
-            len(colorstr) > 2
+            len(get_color_hex(colorstr)) > 1
             for cable in self.cables.values()
             for colorstr in cable.colors
         )


### PR DESCRIPTION
A hex RGB color specifier triggered unintentionally a thicker wire as if a 2 or 3 colored wire was found. Bug reported in issue #494.

Fix: Calling get_color_hex() returns a list of colors specified. Then this if expression should work independently of how each color is specified.