### PR TITLE
Add example projects to docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,13 @@ Read the [syntax description](syntax.md) to learn about WireViz' features and ho
 
 See the [tutorial page](../tutorial/readme.md) for sample code, as well as the [example gallery](../examples/readme.md) to see more of what WireViz can do.
 
+### Example projects and tools
+
+Public projects using or extending WireViz include:
+
+* [CTS-SAT-1 Cable Harnesses](https://github.com/CalgaryToSpace/CTS-SAT-1-Cable-Harnesses), which documents harnesses for CalgaryToSpace's CTS-SAT-1 CubeSat mission. This project was suggested by one of its contributors.
+* [wireviz-web](https://github.com/wireviz/wireviz-web), a web interface for generating WireViz diagrams from YAML input. This tool is maintained in the WireViz organization by a WireViz co-maintainer.
+
 
 ## Usage
 


### PR DESCRIPTION
Closes wireviz/WireViz#466.

This adds a small "Example projects and tools" subsection to the README examples area.

The entries come directly from the issue discussion:

- CalgaryToSpace/CTS-SAT-1-Cable-Harnesses was suggested by one of that project's contributors in the issue body.
- wireviz/wireviz-web was suggested by a WireViz collaborator as a related tool maintained in the WireViz organization.

Validation:

- `git diff --check origin/dev...HEAD`
- `python -m pip install .`
- `PATH=/opt/homebrew/bin:$PATH python src/wireviz/tools/build_examples.py`
- `review-fix-loop`: no discrete correctness, build, or maintainability issues

GitHub Actions currently show `action_required` for this fork branch, so the upstream example-generation workflow has not run yet.
