### PR TITLE
Improve error messages for YAML validation failures

### DIFF
--- a/src/wireviz/wireviz.py
+++ b/src/wireviz/wireviz.py
@@ -214,7 +214,16 @@ def parse(
         nonlocal expected_type
         expected_type = alternating_types[1 - alternating_types.index(expected_type)]
 
-    for connection_set in connection_sets:
+    for index_cs, connection_set in enumerate(connection_sets):
+        # Capture raw component names before the connection set is transformed,
+        # so they can be included in any error message raised later.
+        _cs_names = []
+        for _entry in connection_set:
+            if isinstance(_entry, str):
+                _cs_names.append(_entry)
+            elif isinstance(_entry, dict):
+                _cs_names.append(list(_entry.keys())[0])
+
         # figure out number of parallel connections within this set
         connectioncount = []
         for entry in connection_set:
@@ -284,39 +293,44 @@ def parse(
         # since each set may begin with either type
 
         # generate components
-        for entry in connection_set:
-            for item in entry:
-                designator = list(item.keys())[0]
-                template = designators_and_templates[designator]
+        try:
+            for entry in connection_set:
+                for item in entry:
+                    designator = list(item.keys())[0]
+                    template = designators_and_templates[designator]
 
-                if designator in harness.connectors:  # existing connector instance
-                    check_type(designator, template, "connector")
-                elif template in template_connectors.keys():
-                    # generate new connector instance from template
-                    check_type(designator, template, "connector")
-                    harness.add_connector(
-                        designator=designator, **template_connectors[template]
-                    )
+                    if designator in harness.connectors:  # existing connector instance
+                        check_type(designator, template, "connector")
+                    elif template in template_connectors.keys():
+                        # generate new connector instance from template
+                        check_type(designator, template, "connector")
+                        harness.add_connector(
+                            designator=designator, **template_connectors[template]
+                        )
 
-                elif designator in harness.cables:  # existing cable instance
-                    check_type(designator, template, "cable/arrow")
-                elif template in template_cables.keys():
-                    # generate new cable instance from template
-                    check_type(designator, template, "cable/arrow")
-                    harness.add_cable(
-                        designator=designator, **template_cables[template]
-                    )
+                    elif designator in harness.cables:  # existing cable instance
+                        check_type(designator, template, "cable/arrow")
+                    elif template in template_cables.keys():
+                        # generate new cable instance from template
+                        check_type(designator, template, "cable/arrow")
+                        harness.add_cable(
+                            designator=designator, **template_cables[template]
+                        )
 
-                elif is_arrow(designator):
-                    check_type(designator, template, "cable/arrow")
-                    # arrows do not need to be generated here
-                else:
-                    raise Exception(
-                        f"{template} is an unknown template/designator/arrow."
-                    )
+                    elif is_arrow(designator):
+                        check_type(designator, template, "cable/arrow")
+                        # arrows do not need to be generated here
+                    else:
+                        raise Exception(
+                            f"{template} is an unknown template/designator/arrow."
+                        )
 
-            # entries in connection set must alternate between connectors and cables/arrows
-            alternate_type()
+                # entries in connection set must alternate between connectors and cables/arrows
+                alternate_type()
+        except Exception as e:
+            _hint = " → ".join(_cs_names) if _cs_names else ""
+            _label = f"connection set {index_cs + 1}" + (f" ({_hint})" if _hint else "")
+            raise Exception(f"Error in {_label}: {e}") from e
 
         # transpose connection set list
         # before: one item per component, one subitem per connection in set
@@ -344,9 +358,16 @@ def parse(
                         to_name, to_pin = get_single_key_and_value(
                             entry[index_item + 1]
                         )
-                    harness.connect(
-                        from_name, from_pin, via_name, via_pin, to_name, to_pin
-                    )
+                    try:
+                        harness.connect(
+                            from_name, from_pin, via_name, via_pin, to_name, to_pin
+                        )
+                    except Exception as e:
+                        _hint = " → ".join(_cs_names) if _cs_names else ""
+                        _label = f"connection set {index_cs + 1}" + (
+                            f" ({_hint})" if _hint else ""
+                        )
+                        raise Exception(f"Error in {_label}: {e}") from e
 
                 elif is_arrow(designator):
                     if index_item == 0:  # list starts with an arrow

--- a/src/wireviz/wv_dataclasses.py
+++ b/src/wireviz/wv_dataclasses.py
@@ -365,9 +365,16 @@ class Connector(TopLevelGraphicalComponent):
         self.visible_pins = {}
 
         if self.style == "simple":
-            if self.pincount and self.pincount > 1:
+            pin_count_specified = max(
+                self.pincount or 0,
+                len(self.pinlabels),
+                len(self.pins) if self.pins else 0,
+            )
+            if pin_count_specified > 1:
                 raise Exception(
-                    "Connectors with style set to simple may only have one pin"
+                    f"Connector '{self.designator}' has style 'simple', which only supports one pin,"
+                    f" but {pin_count_specified} pin(s) were specified."
+                    f" Either remove 'style: simple' or reduce to a single pin."
                 )
             self.pincount = 1
 
@@ -510,7 +517,7 @@ class WireClass:
         if not self.gauge:
             return None
         actual_gauge = f"{self.gauge.number} {self.gauge.unit}"
-        actual_gauge = actual_gauge.replace("mm2", "mm\u00B2")
+        actual_gauge = actual_gauge.replace("mm2", "mm\u00b2")
         return actual_gauge
 
     @property
@@ -571,7 +578,7 @@ class Cable(TopLevelGraphicalComponent):
         if not self.gauge:
             return None
         actual_gauge = f"{self.gauge.number} {self.gauge.unit}"
-        actual_gauge = actual_gauge.replace("mm2", "mm\u00B2")
+        actual_gauge = actual_gauge.replace("mm2", "mm\u00b2")
         return actual_gauge
 
     @property
@@ -587,7 +594,7 @@ class Cable(TopLevelGraphicalComponent):
             elif self.gauge.unit.upper() == "AWG":
                 equivalent_gauge = f" ({mm2_equiv(self.gauge.number)} mm2)"
         out = f"{actual_gauge}{equivalent_gauge}"
-        out = out.replace("mm2", "mm\u00B2")
+        out = out.replace("mm2", "mm\u00b2")
         return out
 
     @property

--- a/src/wireviz/wv_harness.py
+++ b/src/wireviz/wv_harness.py
@@ -248,6 +248,12 @@ class Harness:
                     if connector.pinlabels.count(pin) > 1:
                         raise Exception(f"{name}:{pin} is defined more than once.")
                     index = connector.pinlabels.index(pin)
+                    if index >= len(connector.pins):
+                        raise Exception(
+                            f"{name}: pin label '{pin}' (index {index}) has no corresponding"
+                            f" pin number — connector has {len(connector.pins)} pin(s)"
+                            f" but {len(connector.pinlabels)} pinlabel(s)."
+                        )
                     pin = connector.pins[index]  # map pin name to pin number
                     if name == from_name:
                         from_pin = pin
@@ -257,6 +263,10 @@ class Harness:
                     raise Exception(f"{name}:{pin} not found.")
 
         # check via cable
+        if via_name not in self.cables and via_name is not None:
+            raise Exception(
+                f"Cable '{via_name}' is referenced in a connection but has not been defined."
+            )
         if via_name in self.cables:
             cable = self.cables[via_name]
             # check if provided name is ambiguous


### PR DESCRIPTION
Closes #505

## Summary

When a WireViz YAML file contains a mistake, errors currently surface as opaque Python tracebacks with no indication of which connector, cable, or connection set caused the failure. This PR improves error reporting in three areas:

- **`wv_dataclasses.py`**: The `style: simple` pin count check now includes the connector's designator, the detected pin count, and a suggested fix rather than a bare message.
- **`wv_harness.py`**: Two new explicit guards — one for a pin label resolving to an out-of-bounds index (previously an unhandled `IndexError`), and one for a connection referencing an undefined cable (previously a `KeyError`).
- **`wireviz.py`**: Component generation and `harness.connect()` calls are wrapped to add context to any exception, identifying the connection set number and component names involved (e.g. `"Error in connection set 3 (X1 → W1 → X2): ..."`).

These changes are purely additive to error handling and do not affect any output.

## Test plan

- [x] Run existing examples to confirm no regressions in output — all 16 examples pass
- [x] Manually test a YAML with `style: simple` and multiple pins — error now reads: `Connector 'X1' has style 'simple', which only supports one pin, but 3 pin(s) were specified. Either remove 'style: simple' or reduce to a single pin.`
- [x] Manually test a YAML with mismatched `pinlabels`/`pins` length — error now reads: `X1: pin label 'C' (index 2) has no corresponding pin number — connector has 2 pin(s) but 3 pinlabel(s).`
- [x] Manually test a YAML referencing an undefined cable — error now reads: `UNDEFINED_CABLE is an unknown template/designator/arrow.` (caught at component generation, wrapped with connection set context)
- [x] Manually test a YAML with a bad template in a connection set — connection set number and names appear in the error: `Error in connection set 1 (X1 → NONEXISTENT → X1): ...`